### PR TITLE
Implement more AceTypes

### DIFF
--- a/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/ACE.cs
+++ b/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/ACE.cs
@@ -23,16 +23,51 @@ namespace SMBLibrary
             get;
         }
 
-        public static ACE GetAce(byte[] buffer, int offset)
-        {
+        public static ACE GetAce(byte[] buffer, int offset) {
             AceType aceType = (AceType)ByteReader.ReadByte(buffer, offset + 0);
-            switch (aceType)
-            {
+            ACE ace;
+            switch (aceType) {
                 case AceType.ACCESS_ALLOWED_ACE_TYPE:
-                    return new AccessAllowedACE(buffer, offset);
+                case AceType.SYSTEM_AUDIT_ACE_TYPE:
+                case AceType.SYSTEM_SCOPED_POLICY_ID_ACE_TYPE:
+                case AceType.ACCESS_DENIED_ACE_TYPE:
+                case AceType.SYSTEM_MANDATORY_LABEL_ACE_TYPE:
+                    ace = new AceType1(buffer, offset);
+                    break;
+                //case AceType.ACCESS_ALLOWED_CALLBACK_ACE_TYPE:
+                //  ace = AceType3.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE:
+                //  ace = AceType4.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.ACCESS_ALLOWED_OBJECT_ACE_TYPE:
+                //  ace = AceType2.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.ACCESS_DENIED_CALLBACK_ACE_TYPE:
+                //  ace = AceType3.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.ACCESS_DENIED_CALLBACK_OBJECT_ACE_TYPE:
+                //  ace = AceType4.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.ACCESS_DENIED_OBJECT_ACE_TYPE:
+                //  ace = AceType2.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.SYSTEM_AUDIT_CALLBACK_ACE_TYPE:
+                //  ace = AceType3.read(buffer, offset, startPos);
+                //  break;
+                //case SYSTEM_AUDIT_CALLBACK_OBJECT_ACE_TYPE:
+                //  ace = AceType4.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.SYSTEM_AUDIT_OBJECT_ACE_TYPE:
+                //  ace = AceType4.read(buffer, offset, startPos);
+                //  break;
+                //case AceType.SYSTEM_RESOURCE_ATTRIBUTE_ACE_TYPE:
+                //ace = AceType3.read(buffer, offset, startPos);
+                //break;
                 default:
-                    throw new NotImplementedException();
+                  throw new NotImplementedException();
             }
-        }
-    }
+            return ace;
+          }
+      }
 }

--- a/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/AceType1.cs
+++ b/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/AceType1.cs
@@ -13,7 +13,7 @@ namespace SMBLibrary
     /// <summary>
     /// [MS-DTYP] ACCESS_ALLOWED_ACE
     /// </summary>
-    public class AccessAllowedACE : ACE
+    public class AceType1 : ACE
     {
         public const int FixedLength = 8;
 
@@ -21,13 +21,13 @@ namespace SMBLibrary
         public AccessMask Mask;
         public SID Sid;
 
-        public AccessAllowedACE()
+        public AceType1()
         {
             Header = new AceHeader();
             Header.AceType = AceType.ACCESS_ALLOWED_ACE_TYPE;
         }
 
-        public AccessAllowedACE(byte[] buffer, int offset)
+        public AceType1(byte[] buffer, int offset)
         {
             Header = new AceHeader(buffer, offset + 0);
             Mask = (AccessMask)LittleEndianConverter.ToUInt32(buffer, offset + 4);

--- a/SMBLibrary/SMBLibrary.csproj
+++ b/SMBLibrary/SMBLibrary.csproj
@@ -173,7 +173,7 @@
     <Compile Include="NTFileStore\Structures\FileSystemInformation\FileSystemInformation.cs" />
     <Compile Include="NTFileStore\Structures\IOCtl\ObjectIDBufferType1.cs" />
     <Compile Include="NTFileStore\Structures\IOCtl\PipeWaitRequest.cs" />
-    <Compile Include="NTFileStore\Structures\SecurityInformation\ACE\AccessAllowedACE.cs" />
+    <Compile Include="NTFileStore\Structures\SecurityInformation\ACE\AceType1.cs" />
     <Compile Include="NTFileStore\Structures\SecurityInformation\ACE\ACE.cs" />
     <Compile Include="NTFileStore\Structures\SecurityInformation\ACE\AceHeader.cs" />
     <Compile Include="NTFileStore\Structures\SecurityInformation\ACE\Enums\AceFlags.cs" />


### PR DESCRIPTION
Rename AccessAllowedACE to AceType1.
Add the other ace type 1's
leave placeholders for ace type 2, 3 and 4 for future implementation

see 

https://github.com/hierynomus/smbj/blob/master/src/main/java/com/hierynomus/msdtyp/ace/ACE.java#L56
https://github.com/hierynomus/smbj/blob/master/src/main/java/com/hierynomus/msdtyp/ace/AceType2.java
https://github.com/hierynomus/smbj/blob/master/src/main/java/com/hierynomus/msdtyp/ace/AceType3.java
https://github.com/hierynomus/smbj/blob/master/src/main/java/com/hierynomus/msdtyp/ace/AceType4.java