### PR TITLE
Catch PlatformNotSupportedException when setting TCP keepalive.

### DIFF
--- a/SMBLibrary/Utilities/SocketUtils.cs
+++ b/SMBLibrary/Utilities/SocketUtils.cs
@@ -25,12 +25,19 @@ namespace Utilities
         public static void SetKeepAlive(Socket socket, bool enable, TimeSpan timeout, TimeSpan interval)
         {
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-            // https://msdn.microsoft.com/en-us/library/dd877220.aspx
-            byte[] tcp_keepalive = new byte[12];
-            LittleEndianWriter.WriteUInt32(tcp_keepalive, 0, Convert.ToUInt32(enable));
-            LittleEndianWriter.WriteUInt32(tcp_keepalive, 4, (uint)timeout.TotalMilliseconds);
-            LittleEndianWriter.WriteUInt32(tcp_keepalive, 8, (uint)interval.TotalMilliseconds);
-            socket.IOControl(IOControlCode.KeepAliveValues, tcp_keepalive, null);
+            try
+            {
+                // https://msdn.microsoft.com/en-us/library/dd877220.aspx
+                byte[] tcp_keepalive = new byte[12];
+                LittleEndianWriter.WriteUInt32(tcp_keepalive, 0, Convert.ToUInt32(enable));
+                LittleEndianWriter.WriteUInt32(tcp_keepalive, 4, (uint)timeout.TotalMilliseconds);
+                LittleEndianWriter.WriteUInt32(tcp_keepalive, 8, (uint)interval.TotalMilliseconds);
+                socket.IOControl(IOControlCode.KeepAliveValues, tcp_keepalive, null);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Setting the timeout value is only supported by .NET Core on Windows.
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I've found that if you use the library on non-Windows .NET Core platforms it will always crash with a PlatformNotSupportedException when setting the TCP keepalive timeout values. This is because using a raw IOControl code is only implemented for a very limited set of control codes and will throw this exception tearing down the connection.

This patch just wraps the IOControl call inside a try/catch. This ensures if .NET Core adds support later it might start working and is strictly better than checking the platform type. Also I've not tested if Mono implements this IOControl, so it might just work as is. 