### PR TITLE
Fix STATUS_PENDING issues in SMB2FileStore

### DIFF
--- a/SMBLibrary/Client/SMB2FileStore.cs
+++ b/SMBLibrary/Client/SMB2FileStore.cs
@@ -79,7 +79,6 @@ namespace SMBLibrary.Client
             request.ReadLength = (uint)maxCount;
             
             TrySendCommand(request);
-            bool pending = true;
             do
             {
                 SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Read);
@@ -96,9 +95,11 @@ namespace SMBLibrary.Client
 
                     return response.Header.Status;
                 }
-            } while (pending);
-
-            return NTStatus.STATUS_INVALID_SMB;
+                else
+                {
+                    return NTStatus.STATUS_INVALID_SMB;
+                }
+            } while (true);
         }
 
         public NTStatus WriteFile(out int numberOfBytesWritten, object handle, long offset, byte[] data)
@@ -111,7 +112,6 @@ namespace SMBLibrary.Client
             request.Data = data;
 
             TrySendCommand(request);
-            bool pending = true;
             do
             {
                 SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Write);
@@ -127,9 +127,11 @@ namespace SMBLibrary.Client
                     }
                     return response.Header.Status;
                 }
-            } while (pending);
-
-            return NTStatus.STATUS_INVALID_SMB;
+                else
+                {
+                    return NTStatus.STATUS_INVALID_SMB;
+                }
+            } while (true);
         }
 
         public NTStatus FlushFileBuffers(object handle)


### PR DESCRIPTION
I had a problem with my Linux Samba shares where I was not able to read or write files consistently. This was because WaitForCommand would return STATUS_PENDING quite often. I could solve the problem with the code in this pull request. The same issue might occur while listing available shares - but there it happens much less. Just trying again is ok there.

The same is not true for reading and writing files where you get corrupted data if you just try again.

 Maybe it would be good to handle STATUS_PENDING for all methods in the file store.