### PR TITLE
add socket.Dispose.

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -1,5 +1,5 @@
 /* Copyright (C) 2017-2021 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
- * 
+ *
  * You can redistribute this program and/or modify it under the terms of
  * the GNU Lesser Public License as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
@@ -27,7 +27,7 @@ namespace SMBLibrary.Client
         public static readonly uint ClientMaxTransactSize = 1048576;
         public static readonly uint ClientMaxReadSize = 1048576;
         public static readonly uint ClientMaxWriteSize = 1048576;
-        private static readonly ushort DesiredCredits = 16; 
+        private static readonly ushort DesiredCredits = 16;
 
         private SMBTransportType m_transport;
         private bool m_isConnected;
@@ -91,6 +91,9 @@ namespace SMBLibrary.Client
                     if (!(sessionResponsePacket is PositiveSessionResponsePacket))
                     {
                         m_clientSocket.Disconnect(false);
+#if NETSTANDARD2_0
+                        m_clientSocket.Dispose();
+#endif
                         if (!ConnectSocket(serverAddress, port))
                         {
                             return false;
@@ -118,6 +121,9 @@ namespace SMBLibrary.Client
                 if (!supportsDialect)
                 {
                     m_clientSocket.Close();
+#if NETSTANDARD2_0
+                    m_clientSocket.Dispose();
+#endif
                 }
                 else
                 {
@@ -137,6 +143,9 @@ namespace SMBLibrary.Client
             }
             catch (SocketException)
             {
+#if NETSTANDARD2_0
+                m_clientSocket.Dispose();
+#endif
                 return false;
             }
 
@@ -151,6 +160,9 @@ namespace SMBLibrary.Client
             if (m_isConnected)
             {
                 m_clientSocket.Disconnect(false);
+#if NETSTANDARD2_0
+                m_clientSocket.Dispose();
+#endif
                 m_isConnected = false;
             }
         }


### PR DESCRIPTION
Hi, thanks for your great library!  

In Xamarin.iOS, a Socket without Dispose, the instance will continue to remain and will eventually be used up.  
This does not happen on Linux or Xamarin.Android, It seems to be only in Xamarin.iOS.  
\#Net Core 2.0 Linux had the same problem, but it seems to have been fixed now.  

Sample Project:  
[https://github.com/ume05rw/SmbLibrary.SocketTestIos](https://github.com/ume05rw/SmbLibrary.SocketTestIos)  

Test Code:  
[https://github.com/ume05rw/SmbLibrary.SocketTestIos/blob/master/SocketTest/SocketTest/Views/MainViewModel.cs](https://github.com/ume05rw/SmbLibrary.SocketTestIos/blob/master/SocketTest/SocketTest/Views/MainViewModel.cs)