### PR TITLE
Make NetBios and DirectTCP ports configurable

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -21,8 +21,8 @@ namespace SMBLibrary.Client
 {
     public class SMB2Client : ISMBClient
     {
-        public static readonly int NetBiosOverTCPPort = 139;
-        public static readonly int DirectTCPPort = 445;
+        public static int NetBiosOverTCPPort = 139;
+        public static int DirectTCPPort = 445;
 
         public static readonly uint ClientMaxTransactSize = 1048576;
         public static readonly uint ClientMaxReadSize = 1048576;


### PR DESCRIPTION
A very useful enhancement - at least to me - would be the ability to configure the TCP ports used by NetBios and DirectTCP.
Unless there is good reason to have those ports static and fixed to 139/445, I'd suggest making them configurable.
A very easy and sufficient solution would be to remove the "readonly" flag for those two variables.
A better solution would be to have the desired port passed as optional parameter when a connection is created.
Please let me know what you think.