### PR TITLE
Adding STATUS_PATH_NOT_COVERED = 0xC0000257 to NTStatus

### DIFF
--- a/SMBLibrary/Enums/NTStatus.cs
+++ b/SMBLibrary/Enums/NTStatus.cs
@@ -70,6 +70,7 @@ namespace SMBLibrary
         STATUS_PASSWORD_MUST_CHANGE = 0xC0000224,
         STATUS_NOT_A_REPARSE_POINT = 0xC0000275,
 
+        STATUS_PATH_NOT_COVERED = 0xC0000257,
         STATUS_INVALID_SMB = 0x00010002,        // SMB1/CIFS: A corrupt or invalid SMB request was received
         STATUS_SMB_BAD_COMMAND = 0x00160002,    // SMB1/CIFS: An unknown SMB command code was received by the server
         STATUS_SMB_BAD_FID = 0x00060001,        // SMB1/CIFS

--- a/SMBLibrary/Enums/NTStatus.cs
+++ b/SMBLibrary/Enums/NTStatus.cs
@@ -68,8 +68,8 @@ namespace SMBLibrary
         STATUS_NOT_FOUND = 0xC0000225,
         STATUS_ACCOUNT_LOCKED_OUT = 0xC0000234,
         STATUS_PASSWORD_MUST_CHANGE = 0xC0000224,
-        STATUS_NOT_A_REPARSE_POINT = 0xC0000275,
         STATUS_PATH_NOT_COVERED = 0xC0000257,
+        STATUS_NOT_A_REPARSE_POINT = 0xC0000275,
 
         STATUS_INVALID_SMB = 0x00010002,        // SMB1/CIFS: A corrupt or invalid SMB request was received
         STATUS_SMB_BAD_COMMAND = 0x00160002,    // SMB1/CIFS: An unknown SMB command code was received by the server

--- a/SMBLibrary/Enums/NTStatus.cs
+++ b/SMBLibrary/Enums/NTStatus.cs
@@ -69,8 +69,8 @@ namespace SMBLibrary
         STATUS_ACCOUNT_LOCKED_OUT = 0xC0000234,
         STATUS_PASSWORD_MUST_CHANGE = 0xC0000224,
         STATUS_NOT_A_REPARSE_POINT = 0xC0000275,
-
         STATUS_PATH_NOT_COVERED = 0xC0000257,
+
         STATUS_INVALID_SMB = 0x00010002,        // SMB1/CIFS: A corrupt or invalid SMB request was received
         STATUS_SMB_BAD_COMMAND = 0x00160002,    // SMB1/CIFS: An unknown SMB command code was received by the server
         STATUS_SMB_BAD_FID = 0x00060001,        // SMB1/CIFS


### PR DESCRIPTION
Adding this code is helpful for troubleshooting (e.g. it's how I discovered I was attempting to target a DFS server) and will make it easier to add an abstraction layer over SMBLibrary for DFS handling (separate project).

MS-DFSC 3.1.5.1 I/O Operation to Target Fails with STATUS_PATH_NOT_COVERED

When an I/O operation issued to a DFS root target server in step 8 of section 3.1.4.1 fails with STATUS_PATH_NOT_COVERED (0xC0000257), it indicates that the portion of the DFS namespace accessed by the client is not contained in the DFS root target server.