### PR TITLE
SMB2Client - closing the connection correctly

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -166,7 +166,8 @@ namespace SMBLibrary.Client
         {
             if (m_isConnected)
             {
-                m_clientSocket.Disconnect(false);
+                m_clientSocket.Shutdown(SocketShutdown.Both);
+                m_clientSocket.Close();
                 m_isConnected = false;
             }
         }


### PR DESCRIPTION
According to MSDN, for connection-oriented sockets, if you call Connect, you should call Close.
https://stackoverflow.com/questions/31031835/socket-disconnect-vs-socket-close/31032371
https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.shutdown?view=netcore-3.1#remarks