### PR TITLE
Exposes client connection and logged in state to the public API

### DIFF
--- a/SMBLibrary/Client/ISMBClient.cs
+++ b/SMBLibrary/Client/ISMBClient.cs
@@ -37,5 +37,15 @@ namespace SMBLibrary.Client
         {
             get;
         }
+
+        bool IsConnected
+        { 
+            get; 
+        }
+
+        bool IsLoggedIn
+        {
+            get;
+        }
     }
 }


### PR DESCRIPTION
Currently, consumers of the client API's have to store and track the client state themselves when the client already contains this data. This pull request exposes these properties on the client interface and updates v1 & v2 of the SMB clients to expose their internal state via the interface.