### PR TITLE
Provide SPN with NTLMv2 token

### DIFF
--- a/SMBLibrary/Authentication/NTLM/Structures/NTLMv2ClientChallenge.cs
+++ b/SMBLibrary/Authentication/NTLM/Structures/NTLMv2ClientChallenge.cs
@@ -45,12 +45,21 @@ namespace SMBLibrary.Authentication.NTLM
         }
 
         public NTLMv2ClientChallenge(DateTime timeStamp, byte[] clientChallenge, KeyValuePairList<AVPairKey, byte[]> targetInfo)
+            : this(timeStamp, clientChallenge, targetInfo, null)
+        {
+        }
+
+        public NTLMv2ClientChallenge(DateTime timeStamp, byte[] clientChallenge, KeyValuePairList<AVPairKey, byte[]> targetInfo, string spn)
         {
             CurrentVersion = StructureVersion;
             MaximumSupportedVersion = StructureVersion;
             TimeStamp = timeStamp;
             ClientChallenge = clientChallenge;
             AVPairs = targetInfo;
+            if (!string.IsNullOrEmpty(spn))
+            {
+                AVPairs.Add(AVPairKey.TargetName, UnicodeEncoding.Unicode.GetBytes(spn));
+            }
         }
 
         public NTLMv2ClientChallenge(byte[] buffer) : this(buffer, 0)

--- a/SMBLibrary/Client/Helpers/NTLMAuthenticationHelper.cs
+++ b/SMBLibrary/Client/Helpers/NTLMAuthenticationHelper.cs
@@ -75,7 +75,7 @@ namespace SMBLibrary.Client
             }
         }
 
-        public static byte[] GetAuthenticateMessage(byte[] securityBlob, string domainName, string userName, string password, AuthenticationMethod authenticationMethod, out byte[] sessionKey)
+        public static byte[] GetAuthenticateMessage(byte[] securityBlob, string domainName, string userName, string password, string spn, AuthenticationMethod authenticationMethod, out byte[] sessionKey)
         {
             sessionKey = null;
             bool useGSSAPI = false;
@@ -163,7 +163,7 @@ namespace SMBLibrary.Client
             }
             else // NTLMv2
             {
-                NTLMv2ClientChallenge clientChallengeStructure = new NTLMv2ClientChallenge(time, clientChallenge, challengeMessage.TargetInfo);
+                NTLMv2ClientChallenge clientChallengeStructure = new NTLMv2ClientChallenge(time, clientChallenge, challengeMessage.TargetInfo, spn);
                 byte[] clientChallengeStructurePadded = clientChallengeStructure.GetBytesPadded();
                 byte[] ntProofStr = NTLMCryptography.ComputeNTLMv2Proof(challengeMessage.ServerChallenge, clientChallengeStructurePadded, password, userName, domainName);
 

--- a/SMBLibrary/Client/SMB1Client.cs
+++ b/SMBLibrary/Client/SMB1Client.cs
@@ -21,7 +21,7 @@ namespace SMBLibrary.Client
     public class SMB1Client : ISMBClient
     {
         private const string NTLanManagerDialect = "NT LM 0.12";
-        
+
         public static readonly int NetBiosOverTCPPort = 139;
         public static readonly int DirectTCPPort = 445;
 
@@ -90,7 +90,7 @@ namespace SMBLibrary.Client
                 {
                     return false;
                 }
-                
+
                 if (transport == SMBTransportType.NetBiosOverTCP)
                 {
                     SessionRequestPacket sessionRequest = new SessionRequestPacket();
@@ -141,7 +141,7 @@ namespace SMBLibrary.Client
         private bool ConnectSocket(IPAddress serverAddress, int port)
         {
             m_clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            
+
             try
             {
                 m_clientSocket.Connect(serverAddress, port);
@@ -273,7 +273,7 @@ namespace SMBLibrary.Client
                     byte[] proofStr = NTLMCryptography.ComputeNTLMv2Proof(m_serverChallenge, temp, password, userName, domainName);
                     request.UnicodePassword = ByteUtils.Concatenate(proofStr, temp);
                 }
-                
+
                 TrySendMessage(request);
 
                 SMB1Message reply = WaitForMessage(CommandName.SMB_COM_SESSION_SETUP_ANDX);
@@ -305,7 +305,7 @@ namespace SMBLibrary.Client
                     if (reply.Header.Status == NTStatus.STATUS_MORE_PROCESSING_REQUIRED && reply.Commands[0] is SessionSetupAndXResponseExtended)
                     {
                         SessionSetupAndXResponseExtended response = (SessionSetupAndXResponseExtended)reply.Commands[0];
-                        byte[] authenticateMessage = NTLMAuthenticationHelper.GetAuthenticateMessage(response.SecurityBlob, domainName, userName, password, authenticationMethod, out m_sessionKey);
+                        byte[] authenticateMessage = NTLMAuthenticationHelper.GetAuthenticateMessage(response.SecurityBlob, domainName, userName, password, null, authenticationMethod, out m_sessionKey);
                         if (authenticateMessage == null)
                         {
                             return NTStatus.SEC_E_INVALID_TOKEN;

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -224,7 +224,8 @@ namespace SMBLibrary.Client
             {
                 if (response.Header.Status == NTStatus.STATUS_MORE_PROCESSING_REQUIRED && response is SessionSetupResponse)
                 {
-                    byte[] authenticateMessage = NTLMAuthenticationHelper.GetAuthenticateMessage(((SessionSetupResponse)response).SecurityBuffer, domainName, userName, password, authenticationMethod, out m_sessionKey);
+                    string spn = string.Format("cifs/{0}", m_serverName);
+                    byte[] authenticateMessage = NTLMAuthenticationHelper.GetAuthenticateMessage(((SessionSetupResponse)response).SecurityBuffer, domainName, userName, password, spn, authenticationMethod, out m_sessionKey);
                     if (authenticateMessage == null)
                     {
                         return NTStatus.SEC_E_INVALID_TOKEN;


### PR DESCRIPTION
Ensure the `MsvAvTargetName` AV Pair is provided with the NTLM v2
authentication message. This is set to the Service Principal Name (SPN)
of the server being connected to.

This is needed to connect to hosts with the policy https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj852272(v=ws.11) set to `Accept` or `Required`.