### PR TITLE
Add netstandard2.1 build targets & use System.Security.Cryptography.AesCcm when available

### DIFF
--- a/SMBLibrary.Tests/SMBLibrary.Tests.csproj
+++ b/SMBLibrary.Tests/SMBLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>SMBLibrary.Tests</AssemblyName>
     <RootNamespace>SMBLibrary.Tests</RootNamespace>

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -246,7 +246,20 @@ namespace SMBLibrary.Client
                             if (m_dialect == SMB2Dialect.SMB300)
                             {
                                 m_encryptSessionData = (((SessionSetupResponse)response).SessionFlags & SessionFlags.EncryptData) > 0;
-								m_encryptionProvider = EncryptionProvider.GetProvider(m_sessionKey, SMB2Dialect.SMB300);
+
+                                if (m_encryptionProvider != null)
+								{
+                                    m_encryptionProvider.Dispose();
+                                    m_encryptionProvider = null;
+								}
+
+                                if (m_decryptionProvider != null)
+                                {
+                                    m_decryptionProvider.Dispose();
+                                    m_decryptionProvider = null;
+                                }
+
+                                m_encryptionProvider = EncryptionProvider.GetProvider(m_sessionKey, SMB2Dialect.SMB300);
                                 m_decryptionProvider = DecryptionProvider.GetProvider(m_sessionKey, SMB2Dialect.SMB300);
                             }
                         }

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -17,7 +17,7 @@ using Utilities;
 
 namespace SMBLibrary.Client
 {
-	public class SMB2Client : ISMBClient
+	public class SMB2Client : ISMBClient, IDisposable
     {
         public static readonly int NetBiosOverTCPPort = 139;
         public static readonly int DirectTCPPort = 445;
@@ -649,5 +649,36 @@ namespace SMBLibrary.Client
             {
             }
         }
-    }
+
+		public void Dispose()
+		{
+            if (m_decryptionProvider != null)
+            {
+                m_decryptionProvider.Dispose();
+            }
+
+            if (m_encryptionProvider != null)
+            {
+                m_encryptionProvider.Dispose();
+            }
+
+            if (m_clientSocket != null)
+			{
+#if NET40_OR_GREATER
+                m_clientSocket.Dispose();
+#else
+                m_clientSocket.Close();
+#endif
+            }
+
+#if NET40_OR_GREATER
+            m_incomingQueueEventHandle.Dispose();
+            m_sessionResponseEventHandle.Dispose();
+#else
+            m_incomingQueueEventHandle.Close();
+            m_sessionResponseEventHandle.Close();
+#endif
+
+        }
+	}
 }

--- a/SMBLibrary/SMB2/Encryption/DecryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/DecryptionProvider.cs
@@ -1,0 +1,66 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	public abstract class DecryptionProvider : IDisposable
+	{
+		protected readonly byte[] m_decryptionKey;
+		protected bool m_disposedValue;
+
+		protected DecryptionProvider(byte[] decryptionKey)
+		{
+			m_decryptionKey = decryptionKey;
+		}
+		public abstract int NonceLength { get; }
+
+		public abstract byte[] DecryptAndAuthenticate(byte[] nonce, byte[] encryptedData, byte[] associatedData, byte[] signature);
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!m_disposedValue)
+			{
+				m_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+
+
+		/// <summary>
+		/// Gets the appropriate <see cref="EncryptionProvider"/> for the environment.
+		/// </summary>
+		/// <param name="sessionKey">The session key</param>
+		/// <param name="dialect">The dialect to get the key for.</param>
+		/// <returns>An encryption strategy.</returns>
+		public static DecryptionProvider GetProvider(byte[] sessionKey, SMB2Dialect dialect)
+		{
+			byte[] encryptionKey = SMB2Cryptography.GenerateClientDecryptionKey(sessionKey, dialect, null);
+#if NETSTANDARD2_1_OR_GREATER
+			try
+			{
+				return new SystemAesCcmDecryptionProvider(encryptionKey);
+			}
+
+			catch (PlatformNotSupportedException)
+			{
+				return new DefaultAesCcmDecryptionProvider(encryptionKey);
+			}
+#else
+			return new DefaultAesCcmDecryptionProvider(encryptionKey);
+#endif
+
+
+		}
+	}
+}

--- a/SMBLibrary/SMB2/Encryption/DefaultAesCcmDecryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/DefaultAesCcmDecryptionProvider.cs
@@ -1,0 +1,27 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	public class DefaultAesCcmDecryptionProvider : DecryptionProvider
+	{
+		public DefaultAesCcmDecryptionProvider(byte[] decryptionKey) : base(decryptionKey)
+		{
+		}
+
+		public override int NonceLength => 11;
+
+		public override byte[] DecryptAndAuthenticate(byte[] nonce, byte[] encryptedData, byte[] associatedData, byte[] signature)
+		{
+			if (m_disposedValue)
+				throw new ObjectDisposedException(nameof(DefaultAesCcmDecryptionProvider));
+
+			return Utilities.AesCcm.DecryptAndAuthenticate(m_decryptionKey, nonce, encryptedData, associatedData, signature);
+		}
+	}
+}

--- a/SMBLibrary/SMB2/Encryption/DefaultAesCcmEncryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/DefaultAesCcmEncryptionProvider.cs
@@ -1,0 +1,28 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	public class DefaultAesCcmEncryptionProvider : EncryptionProvider
+	{
+		public DefaultAesCcmEncryptionProvider(byte[] encryptionKey) : base(encryptionKey)
+		{
+		}
+
+		public override int NonceLength => 11;
+
+		public override byte[] EncryptMessage(byte[] nonce, byte[] message, byte[] associatedData, out byte[] signature)
+		{
+			if (_disposedValue)
+				throw new ObjectDisposedException(nameof(DefaultAesCcmEncryptionProvider));
+
+			return Utilities.AesCcm.Encrypt(m_encryptionKey, nonce, message, associatedData, SMB2TransformHeader.SignatureLength, out signature);
+		}
+	}
+}

--- a/SMBLibrary/SMB2/Encryption/EncryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/EncryptionProvider.cs
@@ -1,0 +1,74 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	public abstract class EncryptionProvider : IDisposable
+	{
+		protected readonly byte[] m_encryptionKey;
+		private readonly Random m_random;
+		protected bool _disposedValue;
+
+		public abstract int NonceLength { get; }
+
+		protected EncryptionProvider(byte[] encryptionKey)
+		{
+			m_encryptionKey = encryptionKey;
+			m_random = new Random();
+		}
+
+		public abstract byte[] EncryptMessage(byte[] nonce, byte[] message, byte[] assosciatedData, out byte[] signature);
+
+		public byte[] GenerateNonce()
+		{
+			byte[] nonce = new byte[NonceLength];
+			m_random.NextBytes(nonce);
+			return nonce;
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+
+		/// <summary>
+		/// Gets the appropriate <see cref="EncryptionProvider"/> for the environment.
+		/// </summary>
+		/// <param name="sessionKey">The session key</param>
+		/// <param name="dialect">The dialect to get the key for.</param>
+		/// <returns>An encryption strategy.</returns>
+		public static EncryptionProvider GetProvider(byte[] sessionKey, SMB2Dialect dialect)
+		{
+			byte[] encryptionKey = SMB2Cryptography.GenerateClientEncryptionKey(sessionKey, dialect, null);
+#if NETSTANDARD2_1_OR_GREATER
+			try
+			{
+				return new SystemAesCcmEncryptionProvider(encryptionKey);
+			}
+
+			catch (PlatformNotSupportedException)
+			{
+				return new DefaultAesCcmEncryptionProvider(encryptionKey);
+			}
+#else
+			return new DefaultAesCcmEncryptionProvider(encryptionKey);
+#endif
+
+
+		}
+	}
+}

--- a/SMBLibrary/SMB2/Encryption/SystemAesCcmDecryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/SystemAesCcmDecryptionProvider.cs
@@ -1,0 +1,42 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+#if NETSTANDARD2_1_OR_GREATER
+
+using System.Security.Cryptography;
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	/// <summary>
+	/// Encryption strategy which uses the <see cref="System.Security.Cryptography.AesCcm"/> encryption strategy.
+	/// </summary>
+	public class SystemAesCcmDecryptionProvider : DecryptionProvider
+	{
+		private readonly AesCcm _aesCcm;
+
+		public SystemAesCcmDecryptionProvider(byte[] encryptionKey) : base(encryptionKey)
+		{
+			_aesCcm = new AesCcm(encryptionKey);
+		}
+
+		public override int NonceLength => 11;
+
+		public override byte[] DecryptAndAuthenticate(byte[] nonce, byte[] encryptedData, byte[] associatedData, byte[] signature)
+		{
+			byte[] plainText = new byte[encryptedData.Length];
+			_aesCcm.Decrypt(nonce, encryptedData, signature, plainText, associatedData);
+
+			return plainText;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_aesCcm.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+}
+#endif

--- a/SMBLibrary/SMB2/Encryption/SystemAesCcmEncryptionProvider.cs
+++ b/SMBLibrary/SMB2/Encryption/SystemAesCcmEncryptionProvider.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright (C) 2020 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+#if NETSTANDARD2_1_OR_GREATER
+
+using System.Security.Cryptography;
+
+namespace SMBLibrary.SMB2.Encryption
+{
+	/// <summary>
+	/// Encryption strategy which uses the <see cref="System.Security.Cryptography.AesCcm"/> encryption strategy.
+	/// </summary>
+	public class SystemAesCcmEncryptionProvider : EncryptionProvider
+	{
+		private readonly AesCcm _aesCcm;
+
+		public SystemAesCcmEncryptionProvider(byte[] encryptionKey) : base(encryptionKey)
+		{
+			_aesCcm = new AesCcm(m_encryptionKey);
+		}
+
+		public override int NonceLength => 11;
+
+		public override byte[] EncryptMessage(byte[] nonce, byte[] message, byte[] assosciatedData, out byte[] signature)
+		{
+			byte[] cypherText = new byte[message.Length];
+			signature = new byte[SMB2TransformHeader.SignatureLength];
+			_aesCcm.Encrypt(nonce, message, cypherText, signature, assosciatedData);
+
+			return cypherText;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_aesCcm.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+}
+#endif

--- a/SMBLibrary/SMB2/SMB2Cryptography.cs
+++ b/SMBLibrary/SMB2/SMB2Cryptography.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Security.Cryptography;
 using Utilities;
+using AesCcm = Utilities.AesCcm;
 
 namespace SMBLibrary.SMB2
 {

--- a/SMBLibrary/SMBLibrary.csproj
+++ b/SMBLibrary/SMBLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>SMBLibrary</AssemblyName>
     <Version>1.4.8</Version>

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Utilities</AssemblyName>
     <RootNamespace>Utilities</RootNamespace>


### PR DESCRIPTION
Hello, this change uses System.Security.Cryptography.AesCcm class to encrypt and decrypt SMB messages on supported platforms. This performs 4-9x faster than the current encryption scheme and is more resource-efficient. If the scheme is not supported it uses the implementation found in the Utilities library.