### PR TITLE
bugfix: add checks that sessionKey is not null before access it's length

### DIFF
--- a/SMBLibrary/Server/SMB1/SessionSetupHelper.cs
+++ b/SMBLibrary/Server/SMB1/SessionSetupHelper.cs
@@ -38,7 +38,7 @@ namespace SMBLibrary.Server.SMB1
             object accessToken = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.AccessToken);
             bool? isGuest = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.IsGuest) as bool?;
 
-            if (sessionKey.Length > 16)
+            if (sessionKey != null && sessionKey.Length > 16)
             {
                 // [MS-CIFS] 3.3.5.43 If the session key is equal to or longer than 16 bytes, only the least significant 16 bytes MUST be stored in Server.Session.SessionKey
                 sessionKey = ByteReader.ReadBytes(sessionKey, 0, 16);
@@ -128,7 +128,7 @@ namespace SMBLibrary.Server.SMB1
                 object accessToken = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.AccessToken);
                 bool? isGuest = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.IsGuest) as bool?;
 
-                if (sessionKey.Length > 16)
+                if (sessionKey != null && sessionKey.Length > 16)
                 {
                     // [MS-CIFS] 3.3.5.43 If the session key is equal to or longer than 16 bytes, only the least significant 16 bytes MUST be stored in Server.Session.SessionKey
                     sessionKey = ByteReader.ReadBytes(sessionKey, 0, 16);

--- a/SMBLibrary/Server/SMB2/SessionSetupHelper.cs
+++ b/SMBLibrary/Server/SMB2/SessionSetupHelper.cs
@@ -71,7 +71,7 @@ namespace SMBLibrary.Server.SMB2
                 object accessToken = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.AccessToken);
                 bool? isGuest = securityProvider.GetContextAttribute(state.AuthenticationContext, GSSAttributeName.IsGuest) as bool?;
 
-                if (sessionKey.Length > 16)
+                if (sessionKey != null && sessionKey.Length > 16)
                 {
                     // [MS-SMB2] 3.3.1.8 SessionKey MUST be set to the first 16 bytes of the cryptographic key queried from the GSS protocol for this authenticated context.
                     sessionKey = ByteReader.ReadBytes(sessionKey, 0, 16);


### PR DESCRIPTION
I encountered a bug when trying out the SMBServer application on the latest commit with the following configuration:
- Direct TCP Transport (Port 445)
- SMB 2.0 / 2.1

The issue was a null dereference when checking the length of `sessionKey` in `GetSessionSetupResponse`. This code appears to be have been added recently in https://github.com/TalAloni/SMBLibrary/commit/9eba4f51102001cbc16afef00bfeec7c4dfa4bcf. I was able to fix the crash and successfully run the server by simply adding a null check to the if clause.