### PR TITLE
Added a new conversion method from Int64 (ticks) to DateTime

### DIFF
--- a/SMBLibrary/NTFileStore/Structures/FileInformation/QueryDirectory/FileDirectoryInformation.cs
+++ b/SMBLibrary/NTFileStore/Structures/FileInformation/QueryDirectory/FileDirectoryInformation.cs
@@ -33,10 +33,10 @@ namespace SMBLibrary
 
         public FileDirectoryInformation(byte[] buffer, int offset) : base(buffer, offset)
         {
-            CreationTime = DateTime.FromFileTimeUtc(LittleEndianConverter.ToInt64(buffer, offset + 8));
-            LastAccessTime = DateTime.FromFileTimeUtc(LittleEndianConverter.ToInt64(buffer, offset + 16));
-            LastWriteTime = DateTime.FromFileTimeUtc(LittleEndianConverter.ToInt64(buffer, offset + 24));
-            ChangeTime = DateTime.FromFileTimeUtc(LittleEndianConverter.ToInt64(buffer, offset + 32));
+            CreationTime = Conversion.ToFileUtcDateTime(LittleEndianConverter.ToInt64(buffer, offset + 8));
+            LastAccessTime = Conversion.ToFileUtcDateTime(LittleEndianConverter.ToInt64(buffer, offset + 16));
+            LastWriteTime = Conversion.ToFileUtcDateTime(LittleEndianConverter.ToInt64(buffer, offset + 24));
+            ChangeTime = Conversion.ToFileUtcDateTime(LittleEndianConverter.ToInt64(buffer, offset + 32));
             EndOfFile = LittleEndianConverter.ToInt64(buffer, offset + 40);
             AllocationSize = LittleEndianConverter.ToInt64(buffer, offset + 48);
             FileAttributes = (FileAttributes)LittleEndianConverter.ToUInt32(buffer, offset + 56);

--- a/Utilities/Conversion/Conversion.SimpleTypes.cs
+++ b/Utilities/Conversion/Conversion.SimpleTypes.cs
@@ -264,5 +264,13 @@ namespace Utilities
             }
             return result;
         }
+
+        public static DateTime ToFileUtcDateTime(Int64 ticksToConvert)
+        {
+            if (ticksToConvert <= DateTime.MaxValue.Ticks)
+                return DateTime.FromFileTimeUtc(ticksToConvert);
+            
+            return DateTime.MaxValue;
+        }
 	}
 }


### PR DESCRIPTION
Hi,

While using your library I discovered that I have some very old photos on my NAS that has some weird DateTime information (year like 30280 - don't know how that happened) and while doing a `QueryDirectory` on folders that contains those files, I was getting an exception like `OutOfRangeException` in the constructor of the `FileDirectoryInformation` class regarding the conversion of the ticks (Int64) to DateTime. In order to fix that, I wrote a method that check if the received parameter is correct or not.

Thank you.
Evdin