### PR TITLE
Improved documentation to have correct implementation to upload large files

### DIFF
--- a/ClientExamples.md
+++ b/ClientExamples.md
@@ -137,7 +137,7 @@ FileStatus fileStatus;
 status = fileStore.CreateFile(out fileHandle, out fileStatus, remoteFilePath, AccessMask.GENERIC_WRITE | AccessMask.SYNCHRONIZE, FileAttributes.Normal, ShareAccess.None, CreateDisposition.FILE_CREATE, CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT, null);
 if (status == NTStatus.STATUS_SUCCESS)
 {
-    int writeOffset = 0;
+    long writeOffset = 0;
     while (localFileStream.Position < localFileStream.Length)
     {
         byte[] buffer = new byte[(int)client.MaxWriteSize];


### PR DESCRIPTION
The given code example did not work for very large files (multiple GB). The `writeOffset` needs to be a `long`