### PR TITLE
Fix: Incorrect CommandLength calculation in NegotiateResponse

### DIFF
--- a/SMBLibrary/SMB2/Commands/NegotiateResponse.cs
+++ b/SMBLibrary/SMB2/Commands/NegotiateResponse.cs
@@ -105,7 +105,7 @@ namespace SMBLibrary.SMB2
                 }
                 else
                 {
-                    int paddedSecurityBufferLength = (int)Math.Ceiling((double)SecurityBufferLength / 8) * 8;
+                    int paddedSecurityBufferLength = (int)Math.Ceiling((double)SecurityBuffer.Length / 8) * 8;
                     return FixedSize + paddedSecurityBufferLength + NegotiateContext.GetNegotiateContextListLength(NegotiateContextList);
                 }
             }


### PR DESCRIPTION
The SecurityBufferLength was used in the CommandLength calculation of NegotiateResponse, but it hadn't been assigned a value when creating the buffer length. Instead, SecurityBuffer.Length should be directly used. This change ensures the accurate calculation of the CommandLength and resolves the related issues.