### PR TITLE
add function body to NotifyChange and Cancel

### DIFF
--- a/SMBLibrary/Client/SMB2FileStore.cs
+++ b/SMBLibrary/Client/SMB2FileStore.cs
@@ -6,9 +6,7 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using SMBLibrary.SMB2;
-using Utilities;
 
 namespace SMBLibrary.Client
 {
@@ -304,6 +302,7 @@ namespace SMBLibrary.Client
             };
 
             ioRequest = request;
+            // Add some reference for cancelation
             lock (_lock)
             {
                 _activeNotifies[request] = true;
@@ -311,31 +310,28 @@ namespace SMBLibrary.Client
 
             TrySendCommand(request);
 
-            ThreadPool.QueueUserWorkItem(_ =>
+            SMB2Command response = m_client.WaitForCommand(request.MessageID);
+
+            lock (_lock)
             {
-                SMB2Command response = m_client.WaitForCommand(request.MessageID);
-
-                lock (_lock)
+                if (!_activeNotifies.ContainsKey(request))
                 {
-                    if (!_activeNotifies.ContainsKey(request))
-                    {
-                        return;
-                    }
+                    return NTStatus.STATUS_CANCELLED;
                 }
+                // Request is finished
+                _activeNotifies.Remove(request);
+            }
 
-                if (response.Header.Status == NTStatus.STATUS_SUCCESS)
-                {
-                    onNotifyChangeCompleted?.Invoke(response.Header.Status, response.GetBytes(), context);
-                    NotifyChange(out _, handle, completionFilter, watchTree, outputBufferSize, onNotifyChangeCompleted, context);
-                }
-                else
-                {
-                    NTStatus error = response == null ? NTStatus.STATUS_INVALID_SMB : response.Header.Status;
-                    onNotifyChangeCompleted?.Invoke(error, null, context);
-                }
-            });
+            // Timeout occurred
+            if (response == null)
+            {
+                onNotifyChangeCompleted?.Invoke(NTStatus.STATUS_IO_TIMEOUT, null, context);
+                return NTStatus.STATUS_IO_TIMEOUT;
+            }
 
-            return NTStatus.STATUS_PENDING;
+            // Normal response
+            onNotifyChangeCompleted?.Invoke(response.Header.Status, response.GetBytes(), context);
+            return response.Header.Status;
         }
 
         public NTStatus Cancel(object ioRequest)


### PR DESCRIPTION
Hi,

I added function body to your functions:

- NotifyChange(...)
- Cancel(...)

Is it okay to use: `ThreadPool.QueueUserWorkItem(()=>...)` here? Or would you rather have sync call (without extra thread)?

The lines:
```c#
private readonly Dictionary<object, bool> _activeNotifies;
private readonly object _lock = new object();
```
are only to cancel the recursive call.

Now the client can use it like the following code:
```c#
object directoryHandle;
FileStatus fileStatus;
NTStatus createStatus = smb2FileStore.CreateFile(
    out directoryHandle,
    out fileStatus,
    "",
    AccessMask.GENERIC_READ,
    SMBLibrary.FileAttributes.Directory,
    ShareAccess.Read | ShareAccess.Write,
    CreateDisposition.FILE_OPEN,
    CreateOptions.FILE_DIRECTORY_FILE,
    null);

NTStatus notifyStatus = smb2FileStore.NotifyChange(
    out m_ioRequest, 
    directoryHandle, 
    NotifyChangeFilter.FileName | NotifyChangeFilter.DirName | NotifyChangeFilter.Size, 
    true, 
    int.Parse(bufferSizeTextBox.Text), 
    OnNotifyChangeCompleted,  // Your callback
    null); // Custom context, here null
```

PS: I will add unit tests later, if the concept idea is okay.