### PR TITLE
feat: try return incomming status from login request.

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -306,7 +306,7 @@ namespace SMBLibrary.Client
             }
             else
             {
-                return NTStatus.STATUS_INVALID_SMB;
+                return response.Header.Status != null ? response.Header.Status : NTStatus.STATUS_INVALID_SMB;
             }
         }
 
@@ -758,3 +758,4 @@ namespace SMBLibrary.Client
         }
     }
 }
+


### PR DESCRIPTION
this request change comes from an issue i was having while trying to connect ti a server, i was getting the STATUS_INVALID_SMB message but didn't know what was happening until i debugged the library and found out that the user i was trying to connect with was blocked, the message was coming in the response header, but it wasn't returned.

So, it could be useful for others get this message clear instead of having to debug to catch the actual error.
<img width="1354" height="969" alt="image" src="https://github.com/user-attachments/assets/2eab5a49-482f-4aaa-803c-b2cb34669065" />
<img width="541" height="253" alt="image" src="https://github.com/user-attachments/assets/97042285-7c76-41bd-b763-5efbc2d50492" />
