### PR TITLE
fix: Support synchronous CANCEL requests to handle file copy hang issue

### DIFF
--- a/SMBLibrary/Server/ConnectionState/SMB2AsyncContext.cs
+++ b/SMBLibrary/Server/ConnectionState/SMB2AsyncContext.cs
@@ -18,5 +18,10 @@ namespace SMBLibrary.Server
         public ulong SessionID;
         public uint TreeID;
         public object IORequest;
+        
+        /// <summary>
+        /// Original request's MessageID, used to support synchronous CANCEL requests
+        /// </summary>
+        public ulong MessageID;
     }
 }

--- a/SMBLibrary/Server/ConnectionState/SMB2ConnectionState.cs
+++ b/SMBLibrary/Server/ConnectionState/SMB2ConnectionState.cs
@@ -154,6 +154,27 @@ namespace SMBLibrary.Server
             return context;
         }
 
+        /// <summary>
+        /// Get AsyncContext by MessageID, used for handling synchronous CANCEL requests
+        /// </summary>
+        /// <param name="messageID">Original request's MessageID</param>
+        /// <param name="sessionID">Session ID for filtering</param>
+        /// <returns>Found AsyncContext, or null if not found</returns>
+        public SMB2AsyncContext GetAsyncContextByMessageID(ulong messageID, ulong sessionID)
+        {
+            lock (m_pendingRequests)
+            {
+                foreach (var context in m_pendingRequests.Values)
+                {
+                    if (context.MessageID == messageID && context.SessionID == sessionID)
+                    {
+                        return context;
+                    }
+                }
+            }
+            return null;
+        }
+
         public void RemoveAsyncContext(SMB2AsyncContext context)
         {
             lock (m_pendingRequests)

--- a/SMBLibrary/Server/SMB2/CancelHelper.cs
+++ b/SMBLibrary/Server/SMB2/CancelHelper.cs
@@ -16,44 +16,54 @@ namespace SMBLibrary.Server.SMB2
         internal static SMB2Command GetCancelResponse(CancelRequest request, SMB2ConnectionState state)
         {
             SMB2Session session = state.GetSession(request.Header.SessionID);
+            SMB2AsyncContext context = null;
+            
             if (request.Header.IsAsync)
             {
-                SMB2AsyncContext context = state.GetAsyncContext(request.Header.AsyncID);
-                if (context != null)
-                {
-                    ISMBShare share = session.GetConnectedTree(context.TreeID);
-                    OpenFileObject openFile = session.GetOpenFileObject(context.FileID);
-                    NTStatus status = share.FileStore.Cancel(context.IORequest);
-                    if (openFile != null)
-                    {
-                        state.LogToServer(Severity.Information, "Cancel: Requested cancel on '{0}{1}'. NTStatus: {2}, AsyncID: {3}.", share.Name, openFile.Path, status, context.AsyncID);
-                    }
-                    if (status == NTStatus.STATUS_SUCCESS ||
-                        status == NTStatus.STATUS_CANCELLED ||
-                        status == NTStatus.STATUS_NOT_SUPPORTED) // See ChangeNotifyHelper.cs
-                    {
-                        state.RemoveAsyncContext(context);
-                        // [MS-SMB2] If the target request is successfully canceled, the target request MUST be failed by sending
-                        // an ERROR response packet [..] with the status field of the SMB2 header set to STATUS_CANCELLED.
-                        ErrorResponse response = new ErrorResponse(request.CommandName, NTStatus.STATUS_CANCELLED);
-                        response.Header.IsAsync = true;
-                        response.Header.AsyncID = context.AsyncID;
-                        return response;
-                    }
-                    // [MS-SMB2] If the target request is not successfully canceled [..] no response is sent.
-                    // Note: Failing to respond might cause the client to disconnect the connection as per [MS-SMB2] 3.2.6.1 Request Expiration Timer Event
-                    return null;
-                }
-                else
-                {
-                    // [MS-SMB2] If a request is not found [..] no response is sent.
-                    return null;
-                }
+                // Async CANCEL: lookup by AsyncID
+                context = state.GetAsyncContext(request.Header.AsyncID);
             }
             else
             {
-                // [MS-SMB2] the SMB2 CANCEL Request MUST use an ASYNC header for canceling requests that have received an interim response.
+                // Synchronous CANCEL: lookup by MessageID
+                // Some clients (e.g., Windows client) send synchronous CANCEL to cancel requests that have received an interim response
+                context = state.GetAsyncContextByMessageID(request.Header.MessageID, request.Header.SessionID);
+                
+                if (context != null)
+                {
+                    state.LogToServer(Severity.Verbose, "Cancel: Received synchronous CANCEL for async request. MessageID: {0}, AsyncID: {1}.", request.Header.MessageID, context.AsyncID);
+                }
+            }
+            
+            if (context != null)
+            {
+                ISMBShare share = session.GetConnectedTree(context.TreeID);
+                OpenFileObject openFile = session.GetOpenFileObject(context.FileID);
+                NTStatus status = share.FileStore.Cancel(context.IORequest);
+                if (openFile != null)
+                {
+                    state.LogToServer(Severity.Information, "Cancel: Requested cancel on '{0}{1}'. NTStatus: {2}, AsyncID: {3}.", share.Name, openFile.Path, status, context.AsyncID);
+                }
+                if (status == NTStatus.STATUS_SUCCESS ||
+                    status == NTStatus.STATUS_CANCELLED ||
+                    status == NTStatus.STATUS_NOT_SUPPORTED) // See ChangeNotifyHelper.cs
+                {
+                    state.RemoveAsyncContext(context);
+                    // [MS-SMB2] If the target request is successfully canceled, the target request MUST be failed by sending
+                    // an ERROR response packet [..] with the status field of the SMB2 header set to STATUS_CANCELLED.
+                    ErrorResponse response = new ErrorResponse(request.CommandName, NTStatus.STATUS_CANCELLED);
+                    response.Header.IsAsync = true;
+                    response.Header.AsyncID = context.AsyncID;
+                    return response;
+                }
                 // [MS-SMB2] If the target request is not successfully canceled [..] no response is sent.
+                // Note: Failing to respond might cause the client to disconnect the connection as per [MS-SMB2] 3.2.6.1 Request Expiration Timer Event
+                return null;
+            }
+            else
+            {
+                // [MS-SMB2] If a request is not found [..] no response is sent.
+                state.LogToServer(Severity.Verbose, "Cancel: No async context found for MessageID: {0}, IsAsync: {1}.", request.Header.MessageID, request.Header.IsAsync);
                 return null;
             }
         }

--- a/SMBLibrary/Server/SMB2/ChangeNotifyHelper.cs
+++ b/SMBLibrary/Server/SMB2/ChangeNotifyHelper.cs
@@ -22,6 +22,8 @@ namespace SMBLibrary.Server.SMB2
             OpenFileObject openFile = session.GetOpenFileObject(request.FileId);
             bool watchTree = (request.Flags & ChangeNotifyFlags.WatchTree) > 0;
             SMB2AsyncContext asyncContext = state.CreateAsyncContext(request.FileId, state, request.Header.SessionID, request.Header.TreeID);
+            // Set MessageID to support synchronous CANCEL requests
+            asyncContext.MessageID = request.Header.MessageID;
             // We have to make sure that we don't send an interim response after the final response.
             lock (asyncContext)
             {


### PR DESCRIPTION
- Add MessageID field to SMB2AsyncContext
- Add GetAsyncContextByMessageID() method to find AsyncContext by MessageID
- Set MessageID when creating AsyncContext in ChangeNotifyHelper
- Handle synchronous CANCEL in CancelHelper by looking up MessageID

This fixes the issue where clients send synchronous CANCEL requests (IsAsync=0) to cancel CHANGE_NOTIFY operations, which were previously ignored causing the client to hang indefinitely.

Background:
- The SMB2 protocol specification requires CANCEL to use an ASYNC header
- However, real-world clients (including Windows clients) send synchronous CANCEL requests
- The original implementation only handled async CANCEL, causing compatibility issues

<img width="1089" height="963" alt="image" src="https://github.com/user-attachments/assets/0765ad25-ff38-4cb2-bfe6-b79e16250723" />
