### PR TITLE
Expose port-overloaded SMBServer.Start() method to public

### DIFF
--- a/SMBLibrary/Server/SMBServer.cs
+++ b/SMBLibrary/Server/SMBServer.cs
@@ -84,7 +84,7 @@ namespace SMBLibrary.Server
             Start(serverAddress, transport, port, enableSMB1, enableSMB2, enableSMB3, connectionInactivityTimeout);
         }
 
-        protected internal void Start(IPAddress serverAddress, SMBTransportType transport, int port, bool enableSMB1, bool enableSMB2, bool enableSMB3, TimeSpan? connectionInactivityTimeout)
+        public void Start(IPAddress serverAddress, SMBTransportType transport, int port, bool enableSMB1, bool enableSMB2, bool enableSMB3, TimeSpan? connectionInactivityTimeout)
         {
             if (!m_listening)
             {
@@ -490,3 +490,4 @@ namespace SMBLibrary.Server
         }
     }
 }
+


### PR DESCRIPTION
[Windows 11 24H2, Windows Server 2025](https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-ports?tabs=powershell), [smbd](https://samba-team.gitlab.io/samba/htmldocs/manpages/smbd.8.html), and [mount.cifs](https://linux.die.net/man/8/mount.cifs) all now support hosting and connecting to SMB servers via user-defined ports other than the standard `445`. It is possible MacOS also works if you specify a port in the `smb://` url but I have not tried.

To enable what may be an increasingly common pattern of shares hosted on user-defined ports, this change makes public the overload method in `SMBServer.Start()` which allows callers to specify their own port number.