### PR TITLE
Add missing fields to various enum values

### DIFF
--- a/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
@@ -3,7 +3,8 @@ using System;
 namespace SMBLibrary
 {
     /// <summary>
-    /// [MS-DTYP] 2.4.3 - ACCESS_MASK
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7a53f60e-e730-4dfe-bbe9-b21b62eb790b">
+    /// [MS-DTYP] 2.4.3 - ACCESS_MASK</see>
     /// </summary>
     [Flags]
     public enum AccessMask : uint

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/DirectoryAccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/DirectoryAccessMask.cs
@@ -4,7 +4,8 @@ namespace SMBLibrary
 {
     /// <summary>
     /// [MS-SMB] 2.2.1.4.2 - Directory_Access_Mask
-    /// [MS-SMB2] 2.2.13.1.2 - Directory_Access_Mask
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71">
+    /// [MS-SMB2] 2.2.13.1.2 - Directory_Access_Mask</see>
     /// </summary>
     [Flags]
     public enum DirectoryAccessMask : uint

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/FileAccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/FileAccessMask.cs
@@ -4,7 +4,8 @@ namespace SMBLibrary
 {
     /// <summary>
     /// [MS-SMB] 2.2.1.4.1 - File_Pipe_Printer_Access_Mask
-    /// [MS-SMB2] 2.2.13.1.1 - File_Pipe_Printer_Access_Mask
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534">
+    /// [MS-SMB2] 2.2.13.1.1 - File_Pipe_Printer_Access_Mask</see>
     /// </summary>
     [Flags]
     public enum FileAccessMask : uint
@@ -15,6 +16,7 @@ namespace SMBLibrary
         FILE_READ_EA = 0x00000008,
         FILE_WRITE_EA = 0x00000010,
         FILE_EXECUTE = 0x00000020,
+        FILE_DELETE_CHILD = 0x00000040,
         FILE_READ_ATTRIBUTES = 0x00000080,
         FILE_WRITE_ATTRIBUTES = 0x00000100,
         DELETE = 0x00010000,

--- a/SMBLibrary/NTFileStore/Enums/FileSystemInformation/DeviceCharacteristics.cs
+++ b/SMBLibrary/NTFileStore/Enums/FileSystemInformation/DeviceCharacteristics.cs
@@ -2,15 +2,24 @@ using System;
 
 namespace SMBLibrary
 {
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/616b66d5-b335-4e1c-8f87-b4a55e8d3e4a">
+    /// [MS-FSCC] 2.5.10 - FileFsDeviceInformation</see>
+    /// </summary>
     [Flags]
     public enum DeviceCharacteristics : uint
     {
-        RemovableMedia = 0x0001, // FILE_REMOVABLE_MEDIA
-        ReadOnlyDevice = 0x0002, // FILE_READ_ONLY_DEVICE
-        FloppyDiskette = 0x0004, // FILE_FLOPPY_DISKETTE
-        WriteOnceMedia = 0x0008, // FILE_WRITE_ONCE_MEDIA
-        RemoteDevice = 0x0010,   // FILE_REMOTE_DEVICE
-        IsMounted = 0x0020,      // FILE_DEVICE_IS_MOUNTED
-        VirtualVolume = 0x0040,  // FILE_VIRTUAL_VOLUME
+        RemovableMedia = 0x0001,                // FILE_REMOVABLE_MEDIA
+        ReadOnlyDevice = 0x0002,                // FILE_READ_ONLY_DEVICE
+        FloppyDiskette = 0x0004,                // FILE_FLOPPY_DISKETTE
+        WriteOnceMedia = 0x0008,                // FILE_WRITE_ONCE_MEDIA
+        RemoteDevice = 0x0010,                  // FILE_REMOTE_DEVICE
+        IsMounted = 0x0020,                     // FILE_DEVICE_IS_MOUNTED
+        VirtualVolume = 0x0040,                 // FILE_VIRTUAL_VOLUME
+        SecureOpen = 0x0100,                    // FILE_DEVICE_SECURE_OPEN
+        TerminalServicesDevice = 0x1000,        // FILE_CHARACTERISTIC_TS_DEVICE
+        WebDAVDevice = 0x2000,                  // FILE_CHARACTERISTIC_WEBDAV_DEVICE
+        PortableDevice = 0x4000,                // FILE_PORTABLE_DEVICE
+        AllowAppContainerTraversal = 0x20000,   // FILE_DEVICE_ALLOW_APPCONTAINER_TRAVERSAL
     }
 }

--- a/SMBLibrary/NTFileStore/Enums/FileSystemInformation/FileSystemAttributes.cs
+++ b/SMBLibrary/NTFileStore/Enums/FileSystemInformation/FileSystemAttributes.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace SMBLibrary
 {
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ebc7e6e5-4650-4e54-b17c-cf60f6fbeeaa">
+    /// [MS-FSCC] 2.5.1 - FileFsAttributeInformation</see>
+    /// </summary>
     [Flags]
     public enum FileSystemAttributes : uint
     {
@@ -14,6 +18,8 @@ namespace SMBLibrary
         SupportsSparseFiles = 0x0040,            // FILE_SUPPORTS_SPARSE_FILES
         SupportsReparsePoints = 0x0080,          // FILE_SUPPORTS_REPARSE_POINTS
         SupportsRemoteStorage = 0x0100,          // FILE_SUPPORTS_REMOTE_STORAGE
+        ReturnsCleanupResultInfo = 0x0200,       // FILE_RETURNS_CLEANUP_RESULT_INFO
+        SupportsPOSIXUnlinkRename = 0x0400,      // FILE_SUPPORTS_POSIX_UNLINK_RENAME
         VolumeIsCompressed = 0x8000,             // FILE_VOLUME_IS_COMPRESSED
         SupportsObjectIDs = 0x00010000,          // FILE_SUPPORTS_OBJECT_IDS
         SupportsEncryption = 0x00020000,         // FILE_SUPPORTS_ENCRYPTION
@@ -25,5 +31,8 @@ namespace SMBLibrary
         SupportsExtendedAttributes = 0x00800000, // FILE_SUPPORTS_EXTENDED_ATTRIBUTES
         SupportsOpenByFileID = 0x01000000,       // FILE_SUPPORTS_OPEN_BY_FILE_ID
         SupportsUSNJournal = 0x02000000,         // FILE_SUPPORTS_USN_JOURNAL
+        SupportsIntegrityStreams = 0x04000000,   // FILE_SUPPORT_INTEGRITY_STREAMS
+        SupportsBlockRefCounting = 0x08000000,   // FILE_SUPPORTS_BLOCK_REFCOUNTING
+        SupportsSparseVDL = 0x10000000,          // FILE_SUPPORTS_SPARSE_VDL
     }
 }

--- a/SMBLibrary/NTFileStore/Enums/FileSystemInformation/FileSystemControlFlags.cs
+++ b/SMBLibrary/NTFileStore/Enums/FileSystemInformation/FileSystemControlFlags.cs
@@ -1,6 +1,10 @@
 
 namespace SMBLibrary
 {
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e5a70738-7ee4-46d9-a5f7-6644daa49a51">
+    /// [MS-FSCC] 2.5.2 - FileFsControlInformation</see>
+    /// </summary>
     public enum FileSystemControlFlags : uint
     {
         QuotaTrack = 0x00000001,              // FILE_VC_QUOTA_TRACK

--- a/SMBLibrary/NTFileStore/Enums/FileSystemInformation/SectorSizeInformationFlags.cs
+++ b/SMBLibrary/NTFileStore/Enums/FileSystemInformation/SectorSizeInformationFlags.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace SMBLibrary
 {
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/3e75d97f-1d0b-4e47-b435-73c513837a57">
+    /// [MS-FSCC] 2.5.7 - FileFsSectorSizeInformation</see>
+    /// </summary>
     [Flags]
     public enum SectorSizeInformationFlags : uint
     {

--- a/SMBLibrary/NTFileStore/Enums/NotifyChangeFilter.cs
+++ b/SMBLibrary/NTFileStore/Enums/NotifyChangeFilter.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace SMBLibrary
 {
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c">
+    /// [MS-SMB2] 2.2.35 CHANGE_NOTIFY_REQUEST</see>
+    /// </summary>
     [Flags]
     public enum NotifyChangeFilter : uint
     {


### PR DESCRIPTION
Updates several Win32 enums to add some fields that are specified in protocol documents but not yet listed in code.

Add top-level documentation headers to enums pointing to the spec, section number, and URL that defines them in the MS protocols library. This provides users of the library with a clear link to the full protocol specs without duplicating the contents of those specs.