### PR TITLE
AlwaysGrantReadOplock option for immutable file systems

### DIFF
--- a/SMBLibrary.Tests/IntegrationTests/OplockTests.cs
+++ b/SMBLibrary.Tests/IntegrationTests/OplockTests.cs
@@ -1,0 +1,166 @@
+/* Copyright (C) 2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SMBLibrary.Authentication.GSSAPI;
+using SMBLibrary.Authentication.NTLM;
+using SMBLibrary.Client;
+using SMBLibrary.Server;
+using SMBLibrary.SMB2;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace SMBLibrary.Tests.IntegrationTests
+{
+    [TestClass]
+    public class OplockTests
+    {
+        private static Random s_seedGenerator = new Random();
+
+        private int m_serverPort;
+        private SMBServer m_server;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            m_serverPort = 1000 + new Random(s_seedGenerator.Next()).Next(50000);
+
+            SMBShareCollection shares = new SMBShareCollection();
+            shares.Add(new FileSystemShare("Shared", new DummyStore()));
+            
+            IGSSMechanism gssMechanism = new IndependentNTLMAuthenticationProvider((username) => "password");
+            GSSProvider gssProvider = new GSSProvider(gssMechanism);
+            // Grant Oplocks
+            SMBServerOptions options = new SMBServerOptions();
+            options.AlwaysGrantReadOplock = true;
+            m_server = new SMBServer(shares, gssProvider, options);
+            m_server.Start(IPAddress.Loopback, SMBTransportType.DirectTCPTransport, m_serverPort, false, true, false, null);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            m_server.Stop();
+        }
+
+        [TestMethod]
+        public void When_OplockRequestedAndAlwaysGrantReadOplockIsEnabled_OplockIsGranted()
+        {
+            // Arrange
+            SMB2Client client = new SMB2Client();
+            client.Connect(IPAddress.Loopback, SMBTransportType.DirectTCPTransport, m_serverPort);
+            client.Login("", "John", "password");
+            
+            NTStatus status;
+            SMB2FileStore fileStore = (SMB2FileStore)client.TreeConnect("Shared", out status);
+            Assert.AreEqual(NTStatus.STATUS_SUCCESS, status);
+
+            // Act
+            
+            // We use a manual CreateRequest to verify the OplockLevel in the response
+            CreateRequest request = new CreateRequest();
+            request.Name = "test.txt";
+            request.DesiredAccess = AccessMask.GENERIC_READ | AccessMask.SYNCHRONIZE;
+            request.FileAttributes = FileAttributes.Normal;
+            request.ShareAccess = ShareAccess.Read;
+            request.CreateDisposition = CreateDisposition.FILE_OPEN;
+            request.CreateOptions = CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT;
+            request.RequestedOplockLevel = OplockLevel.Level2;
+            request.Header.TreeID = ((uint)typeof(SMB2FileStore).GetField("m_treeID", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(fileStore));
+
+            client.TrySendCommand(request);
+            CreateResponse response = (CreateResponse)client.WaitForCommand(request.MessageID);
+
+            // Assert
+            Assert.AreEqual(NTStatus.STATUS_SUCCESS, response.Header.Status);
+            Assert.AreEqual(OplockLevel.Level2, response.OplockLevel);
+            
+            client.Logoff();
+            client.Disconnect();
+        }
+
+        [TestMethod]
+        public void When_OplockNotRequested_OplockIsNotGranted()
+        {
+            // Arrange
+            SMB2Client client = new SMB2Client();
+            client.Connect(IPAddress.Loopback, SMBTransportType.DirectTCPTransport, m_serverPort);
+            client.Login("", "John", "password");
+            
+            NTStatus status;
+            SMB2FileStore fileStore = (SMB2FileStore)client.TreeConnect("Shared", out status);
+            Assert.AreEqual(NTStatus.STATUS_SUCCESS, status);
+
+            // Act
+            
+            CreateRequest request = new CreateRequest();
+            request.Name = "test.txt";
+            request.DesiredAccess = AccessMask.GENERIC_READ | AccessMask.SYNCHRONIZE;
+            request.FileAttributes = FileAttributes.Normal;
+            request.ShareAccess = ShareAccess.Read;
+            request.CreateDisposition = CreateDisposition.FILE_OPEN;
+            request.CreateOptions = CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT;
+            request.RequestedOplockLevel = OplockLevel.None;
+            request.Header.TreeID = ((uint)typeof(SMB2FileStore).GetField("m_treeID", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(fileStore));
+
+            client.TrySendCommand(request);
+            CreateResponse response = (CreateResponse)client.WaitForCommand(request.MessageID);
+
+            // Assert
+            Assert.AreEqual(NTStatus.STATUS_SUCCESS, response.Header.Status);
+            Assert.AreEqual(OplockLevel.None, response.OplockLevel);
+            
+            client.Logoff();
+            client.Disconnect();
+        }
+    }
+
+    public class DummyStore : INTFileStore
+    {
+        public NTStatus CreateFile(out object handle, out FileStatus fileStatus, string path, AccessMask desiredAccess, FileAttributes fileAttributes, ShareAccess shareAccess, CreateDisposition createDisposition, CreateOptions createOptions, SecurityContext securityContext)
+        {
+            handle = "dummy-handle";
+            fileStatus = FileStatus.FILE_OPENED;
+            return NTStatus.STATUS_SUCCESS;
+        }
+
+        public NTStatus CloseFile(object handle) => NTStatus.STATUS_SUCCESS;
+        public NTStatus ReadFile(out byte[] data, object handle, long offset, int maxCount) { data = new byte[0]; return NTStatus.STATUS_SUCCESS; }
+        public NTStatus WriteFile(out int numberOfBytesWritten, object handle, long offset, byte[] data) { numberOfBytesWritten = data.Length; return NTStatus.STATUS_SUCCESS; }
+        public NTStatus FlushFileBuffers(object handle) => NTStatus.STATUS_SUCCESS;
+        public NTStatus LockFile(object handle, long byteOffset, long length, bool exclusiveLock) => NTStatus.STATUS_SUCCESS;
+        public NTStatus UnlockFile(object handle, long byteOffset, long length) => NTStatus.STATUS_SUCCESS;
+        public NTStatus QueryDirectory(out List<QueryDirectoryFileInformation> result, object handle, string fileName, FileInformationClass informationClass) { result = new List<QueryDirectoryFileInformation>(); return NTStatus.STATUS_SUCCESS; }
+        public NTStatus GetFileInformation(out FileInformation result, object handle, FileInformationClass informationClass)
+        {
+            if (informationClass == FileInformationClass.FileNetworkOpenInformation)
+            {
+                FileNetworkOpenInformation fileInfo = new FileNetworkOpenInformation();
+                fileInfo.CreationTime = DateTime.UtcNow;
+                fileInfo.LastAccessTime = DateTime.UtcNow;
+                fileInfo.LastWriteTime = DateTime.UtcNow;
+                fileInfo.ChangeTime = DateTime.UtcNow;
+                fileInfo.AllocationSize = 0;
+                fileInfo.EndOfFile = 0;
+                fileInfo.FileAttributes = FileAttributes.Normal;
+                result = fileInfo;
+                return NTStatus.STATUS_SUCCESS;
+            }
+            result = null;
+            return NTStatus.STATUS_NOT_SUPPORTED;
+        }
+        public NTStatus SetFileInformation(object handle, FileInformation information) => NTStatus.STATUS_SUCCESS;
+        public NTStatus GetFileSystemInformation(out FileSystemInformation result, FileSystemInformationClass informationClass) { result = null; return NTStatus.STATUS_NOT_SUPPORTED; }
+        public NTStatus GetFileSystemInformation(out FileSystemInformation result, object handle, FileSystemInformationClass informationClass) { result = null; return NTStatus.STATUS_NOT_SUPPORTED; }
+        public NTStatus SetFileSystemInformation(FileSystemInformation information) => NTStatus.STATUS_SUCCESS;
+        public NTStatus GetSecurityInformation(out SecurityDescriptor result, object handle, SecurityInformation securityInformation) { result = null; return NTStatus.STATUS_NOT_SUPPORTED; }
+        public NTStatus SetSecurityInformation(object handle, SecurityInformation securityInformation, SecurityDescriptor securityDescriptor) => NTStatus.STATUS_SUCCESS;
+        public NTStatus NotifyChange(out object ioRequest, object handle, NotifyChangeFilter completionFilter, bool watchTree, int outputBufferSize, OnNotifyChangeCompleted onNotifyChangeCompleted, object context) { ioRequest = null; return NTStatus.STATUS_NOT_SUPPORTED; }
+        public NTStatus Cancel(object ioRequest) => NTStatus.STATUS_SUCCESS;
+        public NTStatus DeviceIOControl(object handle, uint ctlCode, byte[] input, out byte[] output, int maxOutputLength) { output = new byte[0]; return NTStatus.STATUS_SUCCESS; }
+    }
+}

--- a/SMBLibrary/Server/SMB1/NTCreateHelper.cs
+++ b/SMBLibrary/Server/SMB1/NTCreateHelper.cs
@@ -16,7 +16,7 @@ namespace SMBLibrary.Server.SMB1
 {
     internal class NTCreateHelper
     {
-        internal static SMB1Command GetNTCreateResponse(SMB1Header header, NTCreateAndXRequest request, ISMBShare share, SMB1ConnectionState state)
+        internal static SMB1Command GetNTCreateResponse(SMB1Header header, NTCreateAndXRequest request, ISMBShare share, SMB1ConnectionState state, bool alwaysGrantReadOplock)
         {
             SMB1Session session = state.GetSession(header.UID);
             bool isExtended = (request.Flags & NTCreateFlags.NT_CREATE_REQUEST_EXTENDED_RESPONSE) > 0;
@@ -80,11 +80,19 @@ namespace SMBLibrary.Server.SMB1
                 if (isExtended)
                 {
                     NTCreateAndXResponseExtended response = CreateResponseExtendedFromFileInformation(fileInfo, fileID.Value, fileStatus);
+                    if (alwaysGrantReadOplock && (request.Flags & (NTCreateFlags.NT_CREATE_REQUEST_OPLOCK | NTCreateFlags.NT_CREATE_REQUEST_OPBATCH)) > 0)
+                    {
+                        response.OpLockLevel = OpLockLevel.Level2OpLockGranted;
+                    }
                     return response;
                 }
                 else
                 {
                     NTCreateAndXResponse response = CreateResponseFromFileInformation(fileInfo, fileID.Value, fileStatus);
+                    if (alwaysGrantReadOplock && (request.Flags & (NTCreateFlags.NT_CREATE_REQUEST_OPLOCK | NTCreateFlags.NT_CREATE_REQUEST_OPBATCH)) > 0)
+                    {
+                        response.OpLockLevel = OpLockLevel.Level2OpLockGranted;
+                    }
                     return response;
                 }
             }

--- a/SMBLibrary/Server/SMB1/OpenAndXHelper.cs
+++ b/SMBLibrary/Server/SMB1/OpenAndXHelper.cs
@@ -16,7 +16,7 @@ namespace SMBLibrary.Server.SMB1
 {
     internal class OpenAndXHelper
     {
-        internal static SMB1Command GetOpenAndXResponse(SMB1Header header, OpenAndXRequest request, ISMBShare share, SMB1ConnectionState state)
+        internal static SMB1Command GetOpenAndXResponse(SMB1Header header, OpenAndXRequest request, ISMBShare share, SMB1ConnectionState state, bool alwaysGrantReadOplock)
         {
             SMB1Session session = state.GetSession(header.UID);
             bool isExtended = (request.Flags & OpenFlags.SMB_OPEN_EXTENDED_RESPONSE) > 0;
@@ -91,11 +91,21 @@ namespace SMBLibrary.Server.SMB1
                 FileNetworkOpenInformation fileInfo = NTFileStoreHelper.GetNetworkOpenInformation(share.FileStore, handle);
                 if (isExtended)
                 {
-                    return CreateResponseExtendedFromFileInfo(fileInfo, fileID.Value, openResult);
+                    OpenAndXResponseExtended response = CreateResponseExtendedFromFileInfo(fileInfo, fileID.Value, openResult);
+                    if (alwaysGrantReadOplock && (request.Flags & (OpenFlags.REQ_OPLOCK | OpenFlags.REQ_OPLOCK_BATCH)) > 0)
+                    {
+                        response.OpenResults.OpLockGranted = true;
+                    }
+                    return response;
                 }
                 else
                 {
-                    return CreateResponseFromFileInfo(fileInfo, fileID.Value, openResult);
+                    OpenAndXResponse response = CreateResponseFromFileInfo(fileInfo, fileID.Value, openResult);
+                    if (alwaysGrantReadOplock && (request.Flags & (OpenFlags.REQ_OPLOCK | OpenFlags.REQ_OPLOCK_BATCH)) > 0)
+                    {
+                        response.OpenResults.OpLockGranted = true;
+                    }
+                    return response;
                 }
             }
         }

--- a/SMBLibrary/Server/SMB2/CreateHelper.cs
+++ b/SMBLibrary/Server/SMB2/CreateHelper.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary.Server.SMB2
 {
     internal class CreateHelper
     {
-        internal static SMB2Command GetCreateResponse(CreateRequest request, ISMBShare share, SMB2ConnectionState state)
+        internal static SMB2Command GetCreateResponse(CreateRequest request, ISMBShare share, SMB2ConnectionState state, bool alwaysGrantReadOplock)
         {
             SMB2Session session = state.GetSession(request.Header.SessionID);
             string path = request.Name;
@@ -64,6 +64,10 @@ namespace SMBLibrary.Server.SMB2
             {
                 FileNetworkOpenInformation fileInfo = NTFileStoreHelper.GetNetworkOpenInformation(share.FileStore, handle);
                 CreateResponse response = CreateResponseFromFileSystemEntry(fileInfo, fileID.Value, fileStatus);
+                if (alwaysGrantReadOplock && request.RequestedOplockLevel != OplockLevel.None)
+                {
+                    response.OplockLevel = OplockLevel.Level2;
+                }
                 return response;
             }
         }

--- a/SMBLibrary/Server/SMBServer.SMB1.cs
+++ b/SMBLibrary/Server/SMBServer.SMB1.cs
@@ -225,7 +225,7 @@ namespace SMBLibrary.Server
                     }
                     else if (command is OpenAndXRequest)
                     {
-                        return OpenAndXHelper.GetOpenAndXResponse(header, (OpenAndXRequest)command, share, state);
+                        return OpenAndXHelper.GetOpenAndXResponse(header, (OpenAndXRequest)command, share, state, alwaysGrantReadOplock: AlwaysGrantReadOplock);
                     }
                     else if (command is ReadAndXRequest)
                     {
@@ -265,7 +265,7 @@ namespace SMBLibrary.Server
                     }
                     else if (command is NTCreateAndXRequest)
                     {
-                        return NTCreateHelper.GetNTCreateResponse(header, (NTCreateAndXRequest)command, share, state);
+                        return NTCreateHelper.GetNTCreateResponse(header, (NTCreateAndXRequest)command, share, state, alwaysGrantReadOplock: AlwaysGrantReadOplock);
                     }
                     else if (command is NTCancelRequest)
                     {

--- a/SMBLibrary/Server/SMBServer.SMB2.cs
+++ b/SMBLibrary/Server/SMBServer.SMB2.cs
@@ -167,7 +167,7 @@ namespace SMBLibrary.Server
                     }
                     else if (command is CreateRequest)
                     {
-                        return CreateHelper.GetCreateResponse((CreateRequest)command, share, state);
+                        return CreateHelper.GetCreateResponse((CreateRequest)command, share, state, alwaysGrantReadOplock: AlwaysGrantReadOplock);
                     }
                     else if (command is QueryInfoRequest)
                     {

--- a/SMBLibrary/Server/SMBServer.cs
+++ b/SMBLibrary/Server/SMBServer.cs
@@ -41,6 +41,7 @@ namespace SMBLibrary.Server
         private bool m_enableSMB1;
         private bool m_enableSMB2;
         private bool m_enableSMB3;
+        private SMBServerOptions m_options;
         private Socket m_listenerSocket;
         private bool m_listening;
         private DateTime m_serverStartTime;
@@ -48,10 +49,15 @@ namespace SMBLibrary.Server
         public event EventHandler<ConnectionRequestEventArgs> ConnectionRequested;
         public event EventHandler<LogEntry> LogEntryAdded;
 
-        public SMBServer(SMBShareCollection shares, GSSProvider securityProvider)
+        public SMBServer(SMBShareCollection shares, GSSProvider securityProvider) : this(shares, securityProvider, new SMBServerOptions())
+        {
+        }
+
+        public SMBServer(SMBShareCollection shares, GSSProvider securityProvider, SMBServerOptions options)
         {
             m_shares = shares;
             m_securityProvider = securityProvider;
+            m_options = options ?? throw new ArgumentNullException(nameof(options));
             m_services = new NamedPipeShare(shares.ListShares());
             m_serverGuid = Guid.NewGuid();
             m_connectionManager = new ConnectionManager();
@@ -473,6 +479,10 @@ namespace SMBLibrary.Server
         {
             m_connectionManager.ReleaseConnection(clientEndPoint);
         }
+
+        public SMBServerOptions Options => m_options;
+
+        public bool AlwaysGrantReadOplock => m_options.AlwaysGrantReadOplock;
 
         private void Log(Severity severity, string message)
         {

--- a/SMBLibrary/Server/SMBServerOptions.cs
+++ b/SMBLibrary/Server/SMBServerOptions.cs
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+namespace SMBLibrary.Server
+{
+    public class SMBServerOptions
+    {
+        /// <summary>
+        /// DANGEROUS! Can only be safely used with immutable filesystems to allow client-side caching.
+        /// When this option is set to <c>true</c> the underlying filesystem must never change.
+        /// </summary>
+        public bool AlwaysGrantReadOplock { get; set; }
+    }
+}


### PR DESCRIPTION
This adds an option that causes SMB server to give read locks freely. This allows clients that support oplocks to cache file contents. I am using it for serving immutable file systems.