### PR TITLE
Guard receive processing after disconnect

### DIFF
--- a/SMBLibrary/Client/SMB1Client.cs
+++ b/SMBLibrary/Client/SMB1Client.cs
@@ -493,7 +493,7 @@ namespace SMBLibrary.Client
                     m_isConnected = false;
                     state.ReceiveBuffer.Dispose();
                 }
-                else
+                else if (clientSocket.Connected)
                 {
                     NBTConnectionReceiveBuffer buffer = state.ReceiveBuffer;
                     buffer.SetNumberOfBytesReceived(numberOfBytesReceived);

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -443,7 +443,7 @@ namespace SMBLibrary.Client
                     m_isConnected = false;
                     state.ReceiveBuffer.Dispose();
                 }
-                else
+                else if (clientSocket.Connected)
                 {
                     NBTConnectionReceiveBuffer buffer = state.ReceiveBuffer;
                     buffer.SetNumberOfBytesReceived(numberOfBytesReceived);


### PR DESCRIPTION
fixes #344 

In addition to SMB2 over TCP I have also been able to reproduce the bug for both SMB1 and netbios. The fix is implemented according to your suggestion with a slight modification: Moving `if (socket.Connected)` up in the else clause isn't quite good enough, since `ProcessConnectionBuffer(state)` within the else clause can also disconnect the socket in multiple paths.

With this change applied, I can no longer reproduce the bug.

We could also consider either setting additional state or moving m_isConnected up in the Dispose() path so we don't have to rely on `socket.Connected` as a proxy for whether it is valid to fully process the received bytes. I did inspect the socket code and there is no good reason to believe that `Connected` would return true after disconnecting but the comment on the property reads:

`// Gets the connection state of the Socket. This property will return the latest
 // known state of the Socket. When it returns false, the Socket was either never connected
 // or it is not connected anymore. When it returns true, though, there's no guarantee that the Socket
 // is still connected, but only that it was connected at the time of the last IO operation.`

so it is not immediately obvious why this has to be the case.