### PR TITLE
feat(dfs): add DFS referral transport helpers

### DIFF
--- a/SMBLibrary/Client/DFS/DfsPath.cs
+++ b/SMBLibrary/Client/DFS/DfsPath.cs
@@ -1,0 +1,139 @@
+/* Copyright (C) 2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+using System.Collections.Generic;
+
+namespace SMBLibrary.Client.DFS
+{
+    public class DfsPath
+    {
+        private List<string> m_components;
+
+        public DfsPath(string uncPath)
+        {
+            if (uncPath == null)
+            {
+                throw new ArgumentNullException(nameof(uncPath));
+            }
+
+            if (uncPath.Length == 0)
+            {
+                throw new ArgumentException("UNC path must not be empty.", nameof(uncPath));
+            }
+
+            m_components = new List<string>();
+            string[] parts = uncPath.Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string part in parts)
+            {
+                m_components.Add(part);
+            }
+
+            if (m_components.Count == 0)
+            {
+                throw new ArgumentException("UNC path contains no components.", nameof(uncPath));
+            }
+        }
+
+        private DfsPath(List<string> components)
+        {
+            m_components = components;
+        }
+
+        public string ToUncPath()
+        {
+            return @"\\" + String.Join(@"\", m_components.ToArray());
+        }
+
+        public DfsPath ReplacePrefix(DfsPath oldPrefix, DfsPath newPrefix)
+        {
+            List<string> oldComponents = oldPrefix.m_components;
+            List<string> newComponents = newPrefix.m_components;
+
+            if (oldComponents.Count > m_components.Count)
+            {
+                return this;
+            }
+
+            for (int i = 0; i < oldComponents.Count; i++)
+            {
+                if (!String.Equals(m_components[i], oldComponents[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return this;
+                }
+            }
+
+            List<string> result = new List<string>(newComponents);
+            for (int i = oldComponents.Count; i < m_components.Count; i++)
+            {
+                result.Add(m_components[i]);
+            }
+
+            return new DfsPath(result);
+        }
+
+        public override string ToString()
+        {
+            return ToUncPath();
+        }
+
+        public string ServerName
+        {
+            get
+            {
+                return m_components[0];
+            }
+        }
+
+        public string ShareName
+        {
+            get
+            {
+                if (m_components.Count > 1)
+                {
+                    return m_components[1];
+                }
+                return null;
+            }
+        }
+
+        public bool HasOnlyOneComponent
+        {
+            get
+            {
+                return m_components.Count == 1;
+            }
+        }
+
+        public bool IsSysVolOrNetLogon
+        {
+            get
+            {
+                if (m_components.Count < 2)
+                {
+                    return false;
+                }
+
+                string share = m_components[1];
+                return String.Equals(share, "SYSVOL", StringComparison.OrdinalIgnoreCase) ||
+                       String.Equals(share, "NETLOGON", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        public bool IsIpc
+        {
+            get
+            {
+                if (m_components.Count < 2)
+                {
+                    return false;
+                }
+
+                return String.Equals(m_components[1], "IPC$", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/SMBLibrary/Client/DFS/DfsReferralHelper.cs
+++ b/SMBLibrary/Client/DFS/DfsReferralHelper.cs
@@ -1,0 +1,44 @@
+/* Copyright (C) 2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using SMBLibrary.DFS;
+using SMBLibrary.SMB2;
+
+namespace SMBLibrary.Client.DFS
+{
+    public class DfsReferralHelper
+    {
+        // MS-SMB2 §2.2.31: sentinel FileId for DFS referral requests
+        public static readonly FileID DfsReferralFileId = new FileID()
+        {
+            Persistent = 0xFFFFFFFFFFFFFFFF,
+            Volatile = 0xFFFFFFFFFFFFFFFF
+        };
+
+        public static readonly int MaxOutputBufferSize = 8192;
+
+        public static NTStatus GetDfsReferral(ISMBFileStore fileStore, string dfsPath, out ResponseGetDfsReferral referralResponse)
+        {
+            referralResponse = null;
+
+            // MS-DFSC §2.2.2: request V4 referrals (highest version)
+            RequestGetDfsReferral request = new RequestGetDfsReferral();
+            request.MaxReferralLevel = 4;
+            request.RequestFileName = dfsPath;
+            byte[] inputBytes = request.GetBytes();
+
+            byte[] outputBytes;
+            NTStatus status = fileStore.DeviceIOControl(DfsReferralFileId, (uint)IoControlCode.FSCTL_DFS_GET_REFERRALS, inputBytes, out outputBytes, MaxOutputBufferSize);
+
+            if (status == NTStatus.STATUS_SUCCESS && outputBytes != null)
+            {
+                referralResponse = new ResponseGetDfsReferral(outputBytes);
+            }
+
+            return status;
+        }
+    }
+}


### PR DESCRIPTION
Add DfsReferralHelper and DfsPath under SMBLibrary/Client/DFS/ as the transport layer building on the already-merged DFS protocol types.

DfsReferralHelper sends FSCTL_DFS_GET_REFERRALS via DeviceIOControl with the sentinel FileId (MS-SMB2 §2.2.31) and returns a parsed ResponseGetDfsReferral. DfsPath parses UNC paths into components for referral request construction and future path replacement.

These are the building blocks for SMB2DfsFileStore (follow-up chunk).