### PR TITLE
Fix #if NETSTANDARD2_0 conditionals for net5.0+ targets

### DIFF
--- a/SMBLibrary.Tests/SMBLibrary.Tests.csproj
+++ b/SMBLibrary.Tests/SMBLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net9.0</TargetFrameworks>
     <AssemblyName>SMBLibrary.Tests</AssemblyName>
     <RootNamespace>SMBLibrary.Tests</RootNamespace>
     <OutputType>Library</OutputType>
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/SMBLibrary.Tests/TestInitializer.cs
+++ b/SMBLibrary.Tests/TestInitializer.cs
@@ -1,0 +1,15 @@
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SMBLibrary.Tests
+{
+    [TestClass]
+    public class TestInitializer
+    {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext context)
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+    }
+}

--- a/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
+++ b/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
@@ -80,15 +80,15 @@ namespace SMBLibrary.Authentication.NTLM
             ICryptoTransform transform;
             if (DES.IsWeakKey(rgbKey) || DES.IsSemiWeakKey(rgbKey))
             {
-#if NETSTANDARD2_0
-                MethodInfo getTransformCoreMethodInfo = des.GetType().GetMethod("CreateTransformCore", BindingFlags.NonPublic | BindingFlags.Static);
-                object[] getTransformCoreParameters = { mode, des.Padding, rgbKey, rgbIV, des.BlockSize / 8 , des.FeedbackSize / 8,  des.BlockSize / 8, true };
-                transform = getTransformCoreMethodInfo.Invoke(null, getTransformCoreParameters) as ICryptoTransform;
-#else
+#if NETFRAMEWORK
                 DESCryptoServiceProvider desServiceProvider = des as DESCryptoServiceProvider;
                 MethodInfo newEncryptorMethodInfo = desServiceProvider.GetType().GetMethod("_NewEncryptor", BindingFlags.NonPublic | BindingFlags.Instance);
                 object[] encryptorParameters = { rgbKey, mode, rgbIV, desServiceProvider.FeedbackSize, 0 };
                 transform = newEncryptorMethodInfo.Invoke(desServiceProvider, encryptorParameters) as ICryptoTransform;
+#else
+                MethodInfo getTransformCoreMethodInfo = des.GetType().GetMethod("CreateTransformCore", BindingFlags.NonPublic | BindingFlags.Static);
+                object[] getTransformCoreParameters = { mode, des.Padding, rgbKey, rgbIV, des.BlockSize / 8 , des.FeedbackSize / 8,  des.BlockSize / 8, true };
+                transform = getTransformCoreMethodInfo.Invoke(null, getTransformCoreParameters) as ICryptoTransform;
 #endif
             }
             else
@@ -137,10 +137,10 @@ namespace SMBLibrary.Authentication.NTLM
 
         public static Encoding GetOEMEncoding()
         {
-#if NETSTANDARD2_0
-            return ASCIIEncoding.GetEncoding(28591);
-#else
+#if NETFRAMEWORK
             return Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+#else
+            return ASCIIEncoding.GetEncoding(28591);
 #endif
         }
 

--- a/SMBLibrary/NetBios/NBTConnectionReceiveBuffer.cs
+++ b/SMBLibrary/NetBios/NBTConnectionReceiveBuffer.cs
@@ -5,7 +5,7 @@
  * either version 3 of the License, or (at your option) any later version.
  */
 using System;
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
 using System.Buffers;
 #endif
 using System.IO;
@@ -35,7 +35,7 @@ namespace SMBLibrary.NetBios
                 throw new ArgumentException("bufferLength must be large enough to hold the largest possible NBT packet");
             }
 
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             m_buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
 #else
             m_buffer = new byte[bufferLength];
@@ -44,7 +44,7 @@ namespace SMBLibrary.NetBios
 
         public void IncreaseBufferSize(int bufferLength)
         {
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
 #else
             byte[] buffer = new byte[bufferLength];
@@ -55,7 +55,7 @@ namespace SMBLibrary.NetBios
                 m_readOffset = 0;
             }
 
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             ArrayPool<byte>.Shared.Return(m_buffer);
 #endif
             m_buffer = buffer;
@@ -130,7 +130,7 @@ namespace SMBLibrary.NetBios
 
         public void Dispose()
         {
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             if (m_buffer != null)
             {
                 ArrayPool<byte>.Shared.Return(m_buffer);

--- a/SMBLibrary/Utilities/SocketUtils.cs
+++ b/SMBLibrary/Utilities/SocketUtils.cs
@@ -6,7 +6,7 @@
  */
 using System;
 using System.Net.Sockets;
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
 using System.Runtime.InteropServices;
 #endif
 
@@ -14,7 +14,7 @@ namespace Utilities
 {
     public class SocketUtils
     {
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
         private static bool IsDotNetFramework()
         {
             const string DotnetFrameworkDescription = ".NET Framework";
@@ -34,7 +34,7 @@ namespace Utilities
         public static void SetKeepAlive(Socket socket, bool enable, TimeSpan timeout, TimeSpan interval)
         {
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             if (IsDotNetFramework())
             {
 #endif
@@ -44,7 +44,7 @@ namespace Utilities
                 LittleEndianWriter.WriteUInt32(tcp_keepalive, 4, (uint)timeout.TotalMilliseconds);
                 LittleEndianWriter.WriteUInt32(tcp_keepalive, 8, (uint)interval.TotalMilliseconds);
                 socket.IOControl(IOControlCode.KeepAliveValues, tcp_keepalive, null);
-#if NETSTANDARD2_0
+#if !NETFRAMEWORK
             }
             else
             {


### PR DESCRIPTION
## Summary

All `#if NETSTANDARD2_0` conditionals in the codebase are used to distinguish between modern .NET and .NET Framework code paths. However, `NETSTANDARD2_0` is only defined when targeting `netstandard2.0` specifically — it is **not** defined for `net5.0`, `net6.0`, `net8.0`, `net9.0`, etc. This causes those targets to fall into the `#else` branch intended for .NET Framework.

This doesn't affect the current upstream builds (which target `net20;net40;netstandard2.0`), but it causes real bugs for anyone who adds a `net6.0`+ target framework — or for forks that target modern .NET directly.

### Bugs fixed

- **`NTLMCryptography.CreateWeakDesEncryptor`**: `NullReferenceException` when `DES.Create()` is cast to `DESCryptoServiceProvider` (which doesn't exist on modern .NET). This crashes LMv1 hash computation for empty or weak-key passwords.
- **`SocketUtils.SetKeepAlive`**: Falls back to Windows-only `IOControl(IOControlCode.KeepAliveValues)` instead of cross-platform `SocketOptionName.TcpKeepAlive*`, breaking TCP keep-alive on Linux.
- **`NBTConnectionReceiveBuffer`**: Falls back to plain `new byte[]` allocation instead of `ArrayPool`, causing unnecessary memory pressure.

### Fix

Replaced all `#if NETSTANDARD2_0` with `#if !NETFRAMEWORK` (or swapped branches to `#if NETFRAMEWORK` / `#else`). This preserves the exact same behavior for all three current upstream targets (`net20`, `net40`, `netstandard2.0`) while also working correctly for any future `net5.0`+ targets.

### Test improvements

- Added `System.Text.Encoding.CodePages` to the test project and registered the provider via `AssemblyInitialize`, so tests that depend on OEM code pages (encoding 437) pass on non-Windows platforms.
- Added `net9.0` to test target frameworks to verify the fix.

## Test plan

- [x] All 56 tests pass on `net9.0` (which references the `netstandard2.0` build of the library)
- [x] No remaining `#if NETSTANDARD2_0` in the codebase
- [x] Verified that `net10.0` does not define `NETSTANDARD2_0` or `NETFRAMEWORK`

Done with [Claude Code](https://claude.ai/code) (`claude-opus-4-6`).