### PR TITLE
Replace #if NETSTANDARD2_0 with NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER

### DIFF
--- a/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
+++ b/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
@@ -80,7 +80,7 @@ namespace SMBLibrary.Authentication.NTLM
             ICryptoTransform transform;
             if (DES.IsWeakKey(rgbKey) || DES.IsSemiWeakKey(rgbKey))
             {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
                 MethodInfo getTransformCoreMethodInfo = des.GetType().GetMethod("CreateTransformCore", BindingFlags.NonPublic | BindingFlags.Static);
                 object[] getTransformCoreParameters = { mode, des.Padding, rgbKey, rgbIV, des.BlockSize / 8 , des.FeedbackSize / 8,  des.BlockSize / 8, true };
                 transform = getTransformCoreMethodInfo.Invoke(null, getTransformCoreParameters) as ICryptoTransform;
@@ -137,7 +137,7 @@ namespace SMBLibrary.Authentication.NTLM
 
         public static Encoding GetOEMEncoding()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             return ASCIIEncoding.GetEncoding(28591);
 #else
             return Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);

--- a/SMBLibrary/NetBios/NBTConnectionReceiveBuffer.cs
+++ b/SMBLibrary/NetBios/NBTConnectionReceiveBuffer.cs
@@ -5,7 +5,7 @@
  * either version 3 of the License, or (at your option) any later version.
  */
 using System;
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 using System.Buffers;
 #endif
 using System.IO;
@@ -35,7 +35,7 @@ namespace SMBLibrary.NetBios
                 throw new ArgumentException("bufferLength must be large enough to hold the largest possible NBT packet");
             }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             m_buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
 #else
             m_buffer = new byte[bufferLength];
@@ -44,7 +44,7 @@ namespace SMBLibrary.NetBios
 
         public void IncreaseBufferSize(int bufferLength)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
 #else
             byte[] buffer = new byte[bufferLength];
@@ -55,7 +55,7 @@ namespace SMBLibrary.NetBios
                 m_readOffset = 0;
             }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             ArrayPool<byte>.Shared.Return(m_buffer);
 #endif
             m_buffer = buffer;
@@ -130,7 +130,7 @@ namespace SMBLibrary.NetBios
 
         public void Dispose()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             if (m_buffer != null)
             {
                 ArrayPool<byte>.Shared.Return(m_buffer);

--- a/SMBLibrary/Utilities/SocketUtils.cs
+++ b/SMBLibrary/Utilities/SocketUtils.cs
@@ -6,7 +6,7 @@
  */
 using System;
 using System.Net.Sockets;
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 
@@ -14,7 +14,7 @@ namespace Utilities
 {
     public class SocketUtils
     {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
         private static bool IsDotNetFramework()
         {
             const string DotnetFrameworkDescription = ".NET Framework";
@@ -34,7 +34,7 @@ namespace Utilities
         public static void SetKeepAlive(Socket socket, bool enable, TimeSpan timeout, TimeSpan interval)
         {
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             if (IsDotNetFramework())
             {
 #endif
@@ -44,7 +44,7 @@ namespace Utilities
                 LittleEndianWriter.WriteUInt32(tcp_keepalive, 4, (uint)timeout.TotalMilliseconds);
                 LittleEndianWriter.WriteUInt32(tcp_keepalive, 8, (uint)interval.TotalMilliseconds);
                 socket.IOControl(IOControlCode.KeepAliveValues, tcp_keepalive, null);
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             }
             else
             {


### PR DESCRIPTION
## Summary

As suggested in #347, replaces all `#if NETSTANDARD2_0` with `#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER` so the modern .NET code paths are also used when targeting net5.0+.

This is a minimal, drop-in change — no branch reordering, no new dependencies, no new test targets. Identical behavior for the current upstream targets (`net20`, `net40`, `netstandard2.0`).

### Files changed

- `NTLMCryptography.cs` — `CreateWeakDesEncryptor` and `GetOEMEncoding`
- `NBTConnectionReceiveBuffer.cs` — `ArrayPool` usage and disposal
- `SocketUtils.cs` — cross-platform keep-alive and `RuntimeInformation` import

Done with [Claude Code](https://claude.ai/code) (`claude-opus-4-6`).