### PR TITLE
Fix incorrect signature verification on share-level encrypted packets

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -511,7 +511,9 @@ namespace SMBLibrary.Client
             if (packet is SessionMessagePacket)
             {
                 byte[] messageBytes;
-                if (m_dialect >= SMB2Dialect.SMB300 && SMB2TransformHeader.IsTransformHeader(packet.Trailer, 0))
+
+                bool isEncrypted = m_dialect >= SMB2Dialect.SMB300 && SMB2TransformHeader.IsTransformHeader(packet.Trailer, 0);
+                if (isEncrypted)
                 {
                     SMB2TransformHeader transformHeader = new SMB2TransformHeader(packet.Trailer, 0);
                     byte[] encryptedMessage = ByteReader.ReadBytes(packet.Trailer, SMB2TransformHeader.Length, (int)transformHeader.OriginalMessageSize);
@@ -568,7 +570,7 @@ namespace SMBLibrary.Client
                 if (command.Header.MessageID != 0xFFFFFFFFFFFFFFFF || command.Header.Command == SMB2CommandName.OplockBreak)
                 {
                     bool isInterimResponse = ((command.Header.Flags & SMB2PacketHeaderFlags.AsyncCommand) != 0) && command.Header.Status == NTStatus.STATUS_PENDING;
-                    bool shouldBeSigned = m_isLoggedIn && m_signingRequired && !m_encryptSessionData && !isInterimResponse;
+                    bool shouldBeSigned = m_isLoggedIn && m_signingRequired && !isEncrypted && !isInterimResponse;
 
                     // [MS-SMB2] 3.2.5.1.3 If signature verification fails, the client MUST discard the received message. The client MAY also choose to disconnect the connection
                     if (shouldBeSigned && !SMB2Cryptography.VerifySignature(messageBytes, m_dialect, m_signingKey))

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -511,7 +511,6 @@ namespace SMBLibrary.Client
             if (packet is SessionMessagePacket)
             {
                 byte[] messageBytes;
-
                 bool isEncrypted = m_dialect >= SMB2Dialect.SMB300 && SMB2TransformHeader.IsTransformHeader(packet.Trailer, 0);
                 if (isEncrypted)
                 {


### PR DESCRIPTION
### Summary
This PR fixes a bug in SMB2Client where the client incorrectly drops legitimate packets when a specific file share has encryption enabled but global session encryption is disabled.

### Problem description
When a share enforces encryption, the server wraps the response packets in an SMB2TransformHeader. While ProcessPacket successfully detects this and decrypts the payload, it determines whether signature verification should be skipped by checking the session-wide flag m_encryptSessionData (line 573):

bool shouldBeSigned = m_isLoggedIn && m_signingRequired && !m_encryptSessionData && !isInterimResponse;

Because m_encryptSessionData is false in this mixed scenario, shouldBeSigned evaluates to true. The client then attempts to verify the signature of the decrypted message. However, per the [MS-SMB2] 3.2.5.1.1.1 specification, the inner SMB2 header signature field is zeroed out for encrypted traffic, causing the client to log "Invalid SMB2 response signature" and drop valid packets.

### Solution
- Added a local isEncrypted boolean flag at the beginning of ProcessPacket that evaluates whether the incoming packet contains an SMB2TransformHeader
- Updated the shouldBeSigned condition to use !isEncrypted instead of !m_encryptSessionData

This ensures that signature verification is correctly skipped for any successfully decrypted packet, whether it was encrypted at the session level or at the share level.