### PR TITLE
SMBFileStream (& a couple other additions)

### DIFF
--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -253,11 +253,6 @@ namespace SMBLibrary.Client
             if (!CanWrite)
                 throw new NotSupportedException();
 
-            var maxWriteSize = MaxWriteSize;
-
-            if (source.Length > maxWriteSize)
-                throw new IOException($"Write size exceeds maximum write size of {maxWriteSize} bytes.");
-
             byte[] data;
 
             if (offset == 0 && count == source.Length)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -23,7 +23,7 @@ namespace SMBLibrary.Client
             };
 
         private static readonly Dictionary<FileOptions, CreateOptions> FileOptionsToCreateOptionsMap =
-            new Dictionary<FileOptions, CreateOptions>(5)
+            new Dictionary<FileOptions, CreateOptions>(4)
             {
                 { FileOptions.WriteThrough, CreateOptions.FILE_WRITE_THROUGH },
                 { FileOptions.DeleteOnClose, CreateOptions.FILE_DELETE_ON_CLOSE },

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -86,6 +86,44 @@ namespace SMBLibrary.Client
         private long m_position;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="SMBFileStream"/> class using a pre-existing file handle.
+        /// </summary>
+        /// <param name="store">The store to use in this stream.</param>
+        /// <param name="handle">The file handle to use in this stream.</param>
+        /// <param name="ownsHandle">True to close <paramref name="handle"/> when the stream is disposed; otherwise, false.</param>
+        /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>
+        /// <exception cref="ArgumentNullException"><paramref name="store"/> or <paramref name="handle"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="handle"/> is a directory, or <paramref name="ownsHandle"/> is false while <paramref name="ownsStore"/> is true.</exception>
+        /// <exception cref="IOException">An error occured while attempting to read the file's information.</exception>
+        public SMBFileStream(ISMBFileStore store, object handle, bool ownsHandle, bool ownsStore = false)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+
+            if (handle == null)
+                throw new ArgumentNullException(nameof(handle));
+
+            if (ownsStore && !ownsHandle)
+                throw new ArgumentException("A stream that owns the store must also own the handle.");
+
+            var fileInfo = GetFileInformation<FileAllInformation>(store, handle);
+
+            if (fileInfo.StandardInformation.Directory)
+                throw new ArgumentException("Cannot construct a stream with a directory handle.", nameof(handle));
+
+            Name = fileInfo.NameInformation.FileName;
+            Store = store;
+            m_handle = handle;
+            m_ownsHandle = ownsHandle;
+            m_ownsStore = ownsStore;
+            m_earliestSeekablePosition = 0;
+            m_accessMask = fileInfo.AccessInformation.AccessFlags;
+            m_length = fileInfo.StandardInformation.EndOfFile;
+            m_position = m_earliestSeekablePosition;
+            m_disposed = false;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SMBFileStream"/> class using a relative path string.
         /// </summary>
         /// <param name="store">The store to use in this stream.</param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -97,6 +97,12 @@ namespace SMBLibrary.Client
 
             if (fileMode == FileMode.Truncate)
             {
+                if ((fileAccess & FileAccess.Read) != 0)
+                    throw new ArgumentException("FileMode.Truncate cannot be combined with FileAccess.Read");
+
+                if ((fileAccess & FileAccess.Write) == 0)
+                    throw new ArgumentException("FileMode.Truncate must be combined with FileAccess.Write");
+
                 //TODO: throw FileNotFoundException if file does not exist
             }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -64,6 +64,12 @@ namespace SMBLibrary.Client
             FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,
             FileOptions fileOptions = FileOptions.None)
         {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+
+            if (Path.IsPathRooted(path))
+                throw new ArgumentException("Path must be relative", nameof(path));
+
             throw new NotImplementedException();
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -86,7 +86,7 @@ namespace SMBLibrary.Client
         /// </summary>
         /// <param name="store">TODO</param>
         /// <param name="path">TODO</param>
-        /// <param name="fileMode">TODO</param>
+        /// <param name="fileMode">One of the enumeration values that determines how to open or create the file.</param>
         /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
         /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
         /// <param name="fileOptions">A bitwise combination of the enumeration values that specifies additional file options. Default: <see cref="FileOptions.None"/></param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -54,6 +54,9 @@ namespace SMBLibrary.Client
 
             m_disposed = true;
 
+            if (disposeManaged)
+                m_store.CloseFile(m_handle);
+
             base.Dispose(disposeManaged);
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -8,9 +8,9 @@ namespace SMBLibrary.Client
         private const AccessMask FileReadData = (AccessMask)0x01;
         private const AccessMask FileWriteData = (AccessMask)0x02;
 
-        public override bool CanRead => throw new NotImplementedException();
+        public override bool CanRead => !m_disposed && (AccessMask & FileReadData) != 0;
 
-        public override bool CanWrite => throw new NotImplementedException();
+        public override bool CanWrite => !m_disposed && (AccessMask & FileWriteData) != 0;
 
         public override bool CanSeek => throw new NotImplementedException();
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 
@@ -8,6 +9,17 @@ namespace SMBLibrary.Client
     {
         private const AccessMask FileReadData = (AccessMask)0x01;
         private const AccessMask FileWriteData = (AccessMask)0x02;
+
+        private static readonly Dictionary<FileMode, CreateDisposition> _fileModeToCreateDispositionMap =
+            new Dictionary<FileMode, CreateDisposition>(6)
+            {
+                { FileMode.CreateNew, CreateDisposition.FILE_CREATE },
+                { FileMode.Create, CreateDisposition.FILE_SUPERSEDE },
+                { FileMode.Open, CreateDisposition.FILE_OPEN },
+                { FileMode.OpenOrCreate, CreateDisposition.FILE_OPEN_IF },
+                //{ FileMode.Truncate, CreateDisposition. },
+                { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
+            };
 
         public override bool CanRead => !m_disposed && (AccessMask & FileReadData) != 0;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -59,17 +59,18 @@ namespace SMBLibrary.Client
             set => throw new InvalidOperationException();
         }
 
-        public int MaxReadSize => (int)Math.Min(int.MaxValue, m_store.MaxReadSize);
+        public int MaxReadSize => (int)Math.Min(int.MaxValue, Store.MaxReadSize);
 
-        public int MaxWriteSize => (int)Math.Min(int.MaxValue, m_store.MaxWriteSize);
+        public int MaxWriteSize => (int)Math.Min(int.MaxValue, Store.MaxWriteSize);
 
         public string Name { get; }
+
+        public ISMBFileStore Store { get; }
 
         private readonly object m_handle;
         private readonly bool m_ownsStore;
         private readonly long m_earliestSeekablePosition;
         private readonly AccessMask m_accessMask;
-        private readonly ISMBFileStore m_store;
 
         private bool m_disposed;
         private long m_length;
@@ -151,11 +152,11 @@ namespace SMBLibrary.Client
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
 
+                Store = store;
                 m_handle = handle;
                 m_ownsStore = ownsStore;
-                m_store = store;
 
-                status = m_store.GetFileInformation(out var info, m_handle,
+                status = Store.GetFileInformation(out var info, m_handle,
                     FileInformationClass.FileAllInformation);
 
                 if (status != NTStatus.STATUS_SUCCESS)
@@ -187,7 +188,7 @@ namespace SMBLibrary.Client
             if (m_disposed)
                 return;
 
-            var status = m_store.FlushFileBuffers(m_handle);
+            var status = Store.FlushFileBuffers(m_handle);
 
             if (status != NTStatus.STATUS_SUCCESS)
                 throw new IOException($"Could not flush SMB stream. Error status: {status}");
@@ -205,7 +206,7 @@ namespace SMBLibrary.Client
                 throw new ArgumentOutOfRangeException(nameof(value),
                     $"The length of the file must be {m_earliestSeekablePosition} or greater.");
 
-            var status = m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
+            var status = Store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
 
             if (status != NTStatus.STATUS_SUCCESS)
                 throw new IOException($"Could not set file length. Error status: {status}");
@@ -276,7 +277,7 @@ namespace SMBLibrary.Client
 
             while (read < maxBytes)
             {
-                var status = m_store.ReadFile(out var bytes, m_handle, m_position + read, maxBytes - read);
+                var status = Store.ReadFile(out var bytes, m_handle, m_position + read, maxBytes - read);
 
                 if ((status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE) || bytes.Length == 0)
                     break;
@@ -321,7 +322,7 @@ namespace SMBLibrary.Client
             {
                 var bytes = new byte[Math.Min(MaxWriteSize, count - written)];
                 Array.Copy(source, offset + written, bytes, 0, bytes.Length);
-                var status = m_store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
+                var status = Store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
 
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException(
@@ -349,12 +350,12 @@ namespace SMBLibrary.Client
             {
                 try
                 {
-                    m_store.CloseFile(m_handle);
+                    Store.CloseFile(m_handle);
                 }
                 finally
                 {
                     if (m_ownsStore)
-                        m_store.Disconnect();
+                        Store.Disconnect();
                 }
             }
 
@@ -377,7 +378,7 @@ namespace SMBLibrary.Client
                 throw new ArgumentException($"Invalid file information class: {typeof(T)}", e);
             }
 
-            var status = m_store.GetFileInformation(out var result, m_handle, fileInformationClass);
+            var status = Store.GetFileInformation(out var result, m_handle, fileInformationClass);
 
             return status == NTStatus.STATUS_SUCCESS
                 ? (T)result

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -50,7 +50,7 @@ namespace SMBLibrary.Client
         }
 
         /// <summary>
-        /// TODO
+        /// The relative path of the opened file.
         /// </summary>
         public string Name { get; }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -257,6 +257,17 @@ namespace SMBLibrary.Client
             if (source.Length > MaxWriteSize)
                 throw new IOException($"Write size exceeds maximum write size of {maxWriteSize} bytes.");
 
+            byte[] data;
+
+            if (offset == 0 && count == source.Length)
+                data = source;
+
+            else
+            {
+                data = new byte[count];
+                Array.Copy(source, offset, data, 0, count);
+            }
+
             throw new NotImplementedException();
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -128,10 +128,8 @@ namespace SMBLibrary.Client
 
         public override void Flush()
         {
-            if (m_disposed)
-                throw new ObjectDisposedException(GetType().FullName);
-
-            m_store.FlushFileBuffers(m_handle);
+            if (!m_disposed)
+                m_store.FlushFileBuffers(m_handle);
         }
 
         public override void SetLength(long value)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -23,6 +23,10 @@ namespace SMBLibrary.Client
             set => Seek(value, SeekOrigin.Begin);
         }
 
+        public int MaxReadSize => (int)Math.Min(int.MaxValue, m_store.MaxReadSize);
+
+        public int MaxWriteSize => (int)Math.Min(int.MaxValue, m_store.MaxWriteSize);
+
         public string Name => GetFileInformation<FileAlternateNameInformation>().FileName;
 
         private AccessMask AccessMask => GetFileInformation<FileAccessInformation>().AccessFlags;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -83,9 +83,9 @@ namespace SMBLibrary.Client
         private readonly AccessMask m_accessMask;
         private readonly ISMBFileStore m_store;
 
+        private bool m_disposed;
         private long m_length;
         private long m_position;
-        private bool m_disposed;
 
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
             FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -86,7 +86,7 @@ namespace SMBLibrary.Client
         private long m_position;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SMBFileStream"/> class.
+        /// Initializes a new instance of the <see cref="SMBFileStream"/> class using a relative path string.
         /// </summary>
         /// <param name="store">The store to use in this stream.</param>
         /// <param name="path">A relative path to the file that the stream will encapsulate.</param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -100,7 +100,9 @@ namespace SMBLibrary.Client
                 if ((fileAccess & entry.Key) != 0)
                     accessMask |= entry.Value;
 
-            var fileAttributes = (FileAttributes)0; //TODO
+            var fileAttributes = (fileOptions & FileOptions.Encrypted) != 0
+                ? FileAttributes.Encrypted
+                : FileAttributes.Normal;
 
             var shareAccess = (ShareAccess)fileShare & SupportedShareAccessFlags;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -85,7 +85,7 @@ namespace SMBLibrary.Client
         /// TODO
         /// </summary>
         /// <param name="store">TODO</param>
-        /// <param name="path">TODO</param>
+        /// <param name="path">A relative path to the file that the stream will encapsulate.</param>
         /// <param name="fileMode">One of the enumeration values that determines how to open or create the file.</param>
         /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
         /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -308,12 +308,10 @@ namespace SMBLibrary.Client
                         $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}");
 
                 written += writtenThisRound;
+                m_length = Math.Max(m_length, m_position + written);
             }
 
             m_position += count;
-
-            if (m_length < m_position)
-                m_length = m_position;
         }
 
         protected override void Dispose(bool disposeManaged)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -24,7 +24,13 @@ namespace SMBLibrary.Client
 
         private bool m_disposed;
 
-        public override void Flush() => throw new NotImplementedException();
+        public override void Flush()
+        {
+            if (m_disposed)
+                throw new ObjectDisposedException(nameof(SMBFileStream));
+
+            m_store.FlushFileBuffers(m_handle);
+        }
 
         public override void SetLength(long value) => throw new NotImplementedException();
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -69,7 +69,7 @@ namespace SMBLibrary.Client
         private long m_position;
 
         /// <summary>
-        /// TODO
+        /// Initializes a new instance of the <see cref="SMBFileStream"/> class.
         /// </summary>
         /// <param name="store">The store to use in this stream.</param>
         /// <param name="path">A relative path to the file that the stream will encapsulate.</param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -31,6 +31,26 @@ namespace SMBLibrary.Client
                 { FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
             };
 
+        private static T GetFileInformation<T>(ISMBFileStore store, object handle) where T : FileInformation
+        {
+            FileInformationClass fileInformationClass;
+
+            try
+            {
+                fileInformationClass = (FileInformationClass)Enum.Parse(typeof(FileInformationClass), typeof(T).Name);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Invalid file information class: {typeof(T)}", e);
+            }
+
+            var status = store.GetFileInformation(out var result, handle, fileInformationClass);
+
+            return status == NTStatus.STATUS_SUCCESS
+                ? (T)result
+                : throw new IOException($"Could not get file information from SMB file. Error status: {status}");
+        }
+
         public override bool CanRead => !m_disposed && (m_accessMask & AccessMask.FILE_READ_DATA) != 0;
 
         public override bool CanWrite => !m_disposed && (m_accessMask & AccessMask.FILE_WRITE_DATA) != 0;
@@ -165,12 +185,7 @@ namespace SMBLibrary.Client
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
 
-                status = store.GetFileInformation(out var info, handle, FileInformationClass.FileAllInformation);
-
-                if (status != NTStatus.STATUS_SUCCESS)
-                    throw new IOException($"Could not get file information from SMB file. Error status: {status}");
-
-                var fileInfo = (FileAllInformation)info;
+                var fileInfo = GetFileInformation<FileAllInformation>(store, handle);
 
                 Name = fileInfo.NameInformation.FileName;
                 Store = store;
@@ -368,29 +383,5 @@ namespace SMBLibrary.Client
 
             base.Dispose(disposeManaged);
         }
-        /*
-        private T GetFileInformation<T>() where T : FileInformation
-        {
-            if (m_disposed)
-                throw new ObjectDisposedException(GetType().FullName);
-
-            FileInformationClass fileInformationClass;
-
-            try
-            {
-                fileInformationClass = (FileInformationClass)Enum.Parse(typeof(FileInformationClass), typeof(T).Name);
-            }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Invalid file information class: {typeof(T)}", e);
-            }
-
-            var status = Store.GetFileInformation(out var result, m_handle, fileInformationClass);
-
-            return status == NTStatus.STATUS_SUCCESS
-                ? (T)result
-                : throw new IOException($"Could not get file information from SMB file. Error status: {status}");
-        }
-        //*/
     }
 }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -22,17 +22,6 @@ namespace SMBLibrary.Client
                 { FileAccess.Write, FileWriteData },
             };
 
-        private static readonly Dictionary<FileMode, CreateDisposition> FileModeToCreateDispositionMap =
-            new Dictionary<FileMode, CreateDisposition>(6)
-            {
-                { FileMode.CreateNew, CreateDisposition.FILE_CREATE },
-                { FileMode.Create, CreateDisposition.FILE_SUPERSEDE },
-                { FileMode.Open, CreateDisposition.FILE_OPEN },
-                { FileMode.OpenOrCreate, CreateDisposition.FILE_OPEN_IF },
-                { FileMode.Truncate, CreateDisposition.FILE_OVERWRITE },
-                { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
-            };
-
         private static readonly Dictionary<FileOptions, CreateOptions> FileOptionsToCreateOptionsMap =
             new Dictionary<FileOptions, CreateOptions>(5)
             {
@@ -119,7 +108,34 @@ namespace SMBLibrary.Client
 
             var shareAccess = (ShareAccess)fileShare & SupportedShareAccessFlags;
 
-            var createDisposition = FileModeToCreateDispositionMap[fileMode];
+            CreateDisposition createDisposition;
+
+            switch (fileMode)
+            {
+                case FileMode.CreateNew:
+                    createDisposition = CreateDisposition.FILE_CREATE;
+                    break;
+
+                case FileMode.Create:
+                    createDisposition = CreateDisposition.FILE_SUPERSEDE;
+                    break;
+
+                case FileMode.Open:
+                    createDisposition = CreateDisposition.FILE_OPEN;
+                    break;
+
+                case FileMode.OpenOrCreate:
+                case FileMode.Append:
+                    createDisposition = CreateDisposition.FILE_OPEN_IF;
+                    break;
+
+                case FileMode.Truncate:
+                    createDisposition = CreateDisposition.FILE_OVERWRITE;
+                    break;
+
+                default:
+                    throw new InvalidEnumArgumentException(nameof(fileMode), (int)fileMode, typeof(FileMode));
+            }
 
             var createOptions = RequiredCreateFlags;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -232,7 +232,7 @@ namespace SMBLibrary.Client
                     break;
 
                 case SeekOrigin.Current:
-                    target += Position;
+                    target += m_position;
                     break;
 
                 case SeekOrigin.End:

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -43,9 +43,9 @@ namespace SMBLibrary.Client
                 //{ FileOptions.Asynchronous, CreateOptions. },
             };
 
-        public override bool CanRead => !m_disposed && (AccessMask & FileReadData) != 0;
+        public override bool CanRead => !m_disposed && (m_accessMask & FileReadData) != 0;
 
-        public override bool CanWrite => !m_disposed && (AccessMask & FileWriteData) != 0;
+        public override bool CanWrite => !m_disposed && (m_accessMask & FileWriteData) != 0;
 
         public override bool CanSeek => !m_disposed;
 
@@ -63,10 +63,9 @@ namespace SMBLibrary.Client
 
         public string Name { get; }
 
-        private AccessMask AccessMask => GetFileInformation<FileAccessInformation>().AccessFlags;
-
         private readonly object m_handle;
         private readonly bool m_ownsStore;
+        private readonly AccessMask m_accessMask;
         private readonly ISMBFileStore m_store;
 
         private long m_position;
@@ -129,6 +128,7 @@ namespace SMBLibrary.Client
             m_disposed = false;
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;
+            m_accessMask = GetFileInformation<FileAccessInformation>().AccessFlags;
         }
 
         public override void Flush()

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -261,6 +261,10 @@ namespace SMBLibrary.Client
                 Array.Copy(source, offset + written, bytes, 0, bytes.Length);
                 var status = m_store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
 
+                if (writtenThisRound == 0)
+                    throw new IOException(
+                        $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}");
+
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException(
                         $"Could not write to SMB file. Bytes successfully written: {written}. Error status: {status}");

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -71,7 +71,7 @@ namespace SMBLibrary.Client
         /// <summary>
         /// TODO
         /// </summary>
-        /// <param name="store">TODO</param>
+        /// <param name="store">The store to use in this stream.</param>
         /// <param name="path">A relative path to the file that the stream will encapsulate.</param>
         /// <param name="fileMode">One of the enumeration values that determines how to open or create the file.</param>
         /// <param name="fileAccess">A bitwise combination of the enumeration values that determines how the file can be accessed by the stream. Default: <see cref="FileAccess.ReadWrite"/></param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -155,10 +155,10 @@ namespace SMBLibrary.Client
                 m_ownsStore = ownsStore;
                 m_store = store;
 
-                var result = m_store.GetFileInformation(out var info, m_handle,
+                status = m_store.GetFileInformation(out var info, m_handle,
                     FileInformationClass.FileAllInformation);
 
-                if (result != NTStatus.STATUS_SUCCESS)
+                if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not get file information from SMB file. Error status: {status}");
 
                 var fileInfo = (FileAllInformation)info;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -146,28 +146,40 @@ namespace SMBLibrary.Client
             var status = store.CreateFile(out var handle, out var fileStatus, path, accessMask, fileAttributes,
                 shareAccess, createDisposition, createOptions, null);
 
-            if (status != NTStatus.STATUS_SUCCESS)
-                throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
+            try
+            {
+                if (status != NTStatus.STATUS_SUCCESS)
+                    throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
 
-            m_handle = handle;
-            m_ownsStore = ownsStore;
-            m_store = store;
+                m_handle = handle;
+                m_ownsStore = ownsStore;
+                m_store = store;
 
-            var result = m_store.GetFileInformation(out var info, m_handle,
-                FileInformationClass.FileAllInformation);
+                var result = m_store.GetFileInformation(out var info, m_handle,
+                    FileInformationClass.FileAllInformation);
 
-            if (result != NTStatus.STATUS_SUCCESS)
-                throw new IOException($"Could not get file information from SMB file. Error status: {status}");
+                if (result != NTStatus.STATUS_SUCCESS)
+                    throw new IOException($"Could not get file information from SMB file. Error status: {status}");
 
-            var fileInfo = (FileAllInformation)info;
+                var fileInfo = (FileAllInformation)info;
 
-            Name = fileInfo.NameInformation.FileName;
-            m_length = fileInfo.StandardInformation.EndOfFile;
-            m_earliestSeekablePosition = append ? m_length : 0;
-            m_accessMask = fileInfo.AccessInformation.AccessFlags;
+                Name = fileInfo.NameInformation.FileName;
+                m_length = fileInfo.StandardInformation.EndOfFile;
+                m_earliestSeekablePosition = append ? m_length : 0;
+                m_accessMask = fileInfo.AccessInformation.AccessFlags;
 
-            m_position = m_earliestSeekablePosition;
-            m_disposed = false;
+                m_position = m_earliestSeekablePosition;
+                m_disposed = false;
+            }
+            catch
+            {
+                store.CloseFile(handle);
+
+                if (ownsStore)
+                    store.Disconnect();
+
+                throw;
+            }
         }
 
         public override void Flush()

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -49,5 +49,28 @@ namespace SMBLibrary.Client
 
             base.Dispose(disposeManaged);
         }
+
+        private T GetFileInformation<T>() where T : FileInformation
+        {
+            if (m_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
+            FileInformationClass fileInformationClass;
+
+            try
+            {
+                fileInformationClass = (FileInformationClass)Enum.Parse(typeof(FileInformationClass), typeof(T).Name);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Invalid file information class: {typeof(T)}", e);
+            }
+
+            var status = m_store.GetFileInformation(out var result, m_handle, fileInformationClass);
+
+            return status == NTStatus.STATUS_SUCCESS
+                ? (T)result
+                : throw new IOException($"Could not get file information from SMB file. Error status: {status}");
+        }
     }
 }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -23,6 +23,16 @@ namespace SMBLibrary.Client
                 { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
             };
 
+        private static readonly Dictionary<FileOptions, CreateOptions> _fileOptionsToCreateOptionsMap =
+            new Dictionary<FileOptions, CreateOptions>(5)
+            {
+                { FileOptions.WriteThrough, CreateOptions.FILE_WRITE_THROUGH },
+                { FileOptions.DeleteOnClose, CreateOptions.FILE_DELETE_ON_CLOSE },
+                //{ FileOptions.SequentialScan, CreateOptions.FILE_SEQUENTIAL_ONLY },
+                //{ FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
+                //{ FileOptions.Asynchronous, CreateOptions. },
+            };
+
         public override bool CanRead => !m_disposed && (AccessMask & FileReadData) != 0;
 
         public override bool CanWrite => !m_disposed && (AccessMask & FileWriteData) != 0;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -49,20 +49,6 @@ namespace SMBLibrary.Client
             set => Seek(value, SeekOrigin.Begin);
         }
 
-        public override bool CanTimeout => false;
-
-        public override int ReadTimeout
-        {
-            get => throw new InvalidOperationException();
-            set => throw new InvalidOperationException();
-        }
-
-        public override int WriteTimeout
-        {
-            get => throw new InvalidOperationException();
-            set => throw new InvalidOperationException();
-        }
-
         /// <summary>
         /// TODO
         /// </summary>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -179,10 +179,6 @@ namespace SMBLibrary.Client
             catch
             {
                 store.CloseFile(handle);
-
-                if (ownsStore)
-                    store.Disconnect();
-
                 throw;
             }
         }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -59,10 +59,6 @@ namespace SMBLibrary.Client
             set => throw new InvalidOperationException();
         }
 
-        public int MaxReadSize => (int)Math.Min(int.MaxValue, Store.MaxReadSize);
-
-        public int MaxWriteSize => (int)Math.Min(int.MaxValue, Store.MaxWriteSize);
-
         public string Name { get; }
 
         public ISMBFileStore Store { get; }
@@ -277,7 +273,7 @@ namespace SMBLibrary.Client
             if (!CanRead)
                 throw new NotSupportedException();
 
-            var maxBytes = Math.Min(MaxReadSize, count);
+            var maxBytes = Math.Min((int)Math.Min(int.MaxValue, Store.MaxReadSize), count);
             var read = 0;
 
             while (read < maxBytes)
@@ -325,7 +321,7 @@ namespace SMBLibrary.Client
 
             while (written < count)
             {
-                var bytes = new byte[Math.Min(MaxWriteSize, count - written)];
+                var bytes = new byte[Math.Min((int)Math.Min(int.MaxValue, Store.MaxWriteSize), count - written)];
                 Array.Copy(source, offset + written, bytes, 0, bytes.Length);
                 var status = Store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -87,10 +87,10 @@ namespace SMBLibrary.Client
         /// <param name="store">TODO</param>
         /// <param name="path">TODO</param>
         /// <param name="fileMode">TODO</param>
-        /// <param name="fileAccess">TODO</param>
-        /// <param name="fileShare">TODO</param>
-        /// <param name="fileOptions">TODO</param>
-        /// <param name="ownsStore">TODO</param>
+        /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
+        /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
+        /// <param name="fileOptions">TODO Default <see cref="FileOptions.None"/></param>
+        /// <param name="ownsStore">TODO Default: false</param>
         /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/>> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>
         /// <exception cref="InvalidEnumArgumentException"><paramref name="fileMode"/> contains an invalid value.</exception>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -14,6 +14,13 @@ namespace SMBLibrary.Client
 
         private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
 
+        private static readonly Dictionary<FileAccess, AccessMask> FileAccessToAccessMaskMap =
+            new Dictionary<FileAccess, AccessMask>(2)
+            {
+                { FileAccess.Read, FileReadData },
+                { FileAccess.Write, FileWriteData },
+            };
+
         private static readonly Dictionary<FileMode, CreateDisposition> FileModeToCreateDispositionMap =
             new Dictionary<FileMode, CreateDisposition>(6)
             {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -24,6 +24,8 @@ namespace SMBLibrary.Client
 
         public string Name => GetFileInformation<FileAlternateNameInformation>().FileName;
 
+        private AccessMask AccessMask => GetFileInformation<FileAccessInformation>().AccessFlags;
+
         private readonly object m_handle;
         private readonly ISMBFileStore m_store;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -270,13 +270,13 @@ namespace SMBLibrary.Client
                 Array.Copy(source, offset + written, bytes, 0, bytes.Length);
                 var status = m_store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
 
-                if (writtenThisRound == 0)
-                    throw new IOException(
-                        $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}");
-
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException(
                         $"Could not write to SMB file. Bytes successfully written: {written}. Error status: {status}");
+
+                if (writtenThisRound == 0)
+                    throw new IOException(
+                        $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}");
 
                 written += writtenThisRound;
             }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -129,8 +129,13 @@ namespace SMBLibrary.Client
 
         public override void Flush()
         {
-            if (!m_disposed)
-                m_store.FlushFileBuffers(m_handle);
+            if (m_disposed)
+                return;
+
+            var status = m_store.FlushFileBuffers(m_handle);
+
+            if (status != NTStatus.STATUS_SUCCESS)
+                throw new IOException($"Could not flush SMB stream. Error status: {status}");
         }
 
         public override void SetLength(long value)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -5,6 +5,9 @@ using System.IO;
 
 namespace SMBLibrary.Client
 {
+    /// <summary>
+    /// TODO
+    /// </summary>
     public sealed class SMBFileStream : Stream
     {
         private const AccessMask FileReadData = (AccessMask)0x01;
@@ -59,8 +62,14 @@ namespace SMBLibrary.Client
             set => throw new InvalidOperationException();
         }
 
+        /// <summary>
+        /// TODO
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// TODO
+        /// </summary>
         public ISMBFileStore Store { get; }
 
         private readonly object m_handle;
@@ -72,6 +81,20 @@ namespace SMBLibrary.Client
         private long m_length;
         private long m_position;
 
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="store">TODO</param>
+        /// <param name="path">TODO</param>
+        /// <param name="fileMode">TODO</param>
+        /// <param name="fileAccess">TODO</param>
+        /// <param name="fileShare">TODO</param>
+        /// <param name="fileOptions">TODO</param>
+        /// <param name="ownsStore">TODO</param>
+        /// <exception cref="ArgumentNullException">TODO</exception>
+        /// <exception cref="ArgumentException">TODO</exception>
+        /// <exception cref="InvalidEnumArgumentException">TODO</exception>
+        /// <exception cref="IOException">TODO</exception>
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
             FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,
             FileOptions fileOptions = FileOptions.None, bool ownsStore = false)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -117,7 +117,26 @@ namespace SMBLibrary.Client
             if (!CanRead)
                 throw new NotSupportedException();
 
-            throw new NotImplementedException();
+            var startingPosition = GetFileInformation<FilePositionInformation>().CurrentByteOffset;
+
+            var maxBytes = Math.Min(MaxReadSize, destination.Length);
+            var read = 0;
+
+            while (read < maxBytes)
+            {
+                var status = m_store.ReadFile(out var bytes, m_handle, startingPosition + read, maxBytes - read);
+
+                if ((status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE) || bytes.Length == 0)
+                    break;
+
+                Array.Copy(bytes, 0, destination, offset + read, bytes.Length);
+                read += bytes.Length;
+
+                if (status == NTStatus.STATUS_END_OF_FILE)
+                    break;
+            }
+
+            return read;
         }
 
         public override void Write(byte[] source, int offset, int count)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -49,7 +49,7 @@ namespace SMBLibrary.Client
 
         public override bool CanSeek => !m_disposed;
 
-        public override long Length => GetFileInformation<FileStandardInformation>().EndOfFile;
+        public override long Length => m_disposed ? throw new ObjectDisposedException(GetType().FullName) : m_length;
 
         public override long Position
         {
@@ -83,6 +83,7 @@ namespace SMBLibrary.Client
         private readonly AccessMask m_accessMask;
         private readonly ISMBFileStore m_store;
 
+        private long m_length;
         private long m_position;
         private bool m_disposed;
 
@@ -152,8 +153,8 @@ namespace SMBLibrary.Client
             m_disposed = false;
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;
-            m_earliestSeekablePosition =
-                fileMode == FileMode.Append ? GetFileInformation<FileStandardInformation>().EndOfFile : 0;
+            m_length = GetFileInformation<FileStandardInformation>().EndOfFile;
+            m_earliestSeekablePosition = fileMode == FileMode.Append ? m_length : 0;
             m_accessMask = GetFileInformation<FileAccessInformation>().AccessFlags;
         }
 
@@ -185,13 +186,17 @@ namespace SMBLibrary.Client
             if (status != NTStatus.STATUS_SUCCESS)
                 throw new IOException($"Could not set file length. Error status: {status}");
 
+            m_length = value;
+
             if (m_position > value)
                 m_position = value;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            var length = Length;
+            if (m_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
             var target = offset;
 
             switch (origin)
@@ -205,7 +210,7 @@ namespace SMBLibrary.Client
                     break;
 
                 case SeekOrigin.End:
-                    target += length;
+                    target += m_length;
                     break;
 
                 default:
@@ -215,7 +220,7 @@ namespace SMBLibrary.Client
             if (target < m_earliestSeekablePosition)
                 throw new IOException("Cannot seek before beginning of stream.");
 
-            if (target > length)
+            if (target > m_length)
                 throw new IOException("Cannot seek past end of stream.");
 
             m_position = target;
@@ -309,6 +314,9 @@ namespace SMBLibrary.Client
             }
 
             m_position += count;
+
+            if (m_length < m_position)
+                m_length = m_position;
         }
 
         protected override void Dispose(bool disposeManaged)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -116,7 +116,31 @@ namespace SMBLibrary.Client
             throw new NotImplementedException();
         }
 
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+        public override void Write(byte[] source, int offset, int count)
+        {
+            if (m_disposed)
+                throw new ObjectDisposedException(nameof(SMBFileStream));
+
+            if (count == 0)
+                return;
+
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (source.Length - offset < count)
+                throw new ArgumentException("Offset and count exceed source bounds.");
+
+            if (!CanWrite)
+                throw new NotSupportedException();
+
+            throw new NotImplementedException();
+        }
 
         protected override void Dispose(bool disposeManaged)
         {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -137,9 +137,6 @@ namespace SMBLibrary.Client
             m_ownsStore = ownsStore;
             m_store = store;
 
-            m_position = m_earliestSeekablePosition;
-            m_disposed = false;
-
             var result = m_store.GetFileInformation(out var info, m_handle,
                 FileInformationClass.FileAllInformation);
 
@@ -152,6 +149,9 @@ namespace SMBLibrary.Client
             m_length = fileInfo.StandardInformation.EndOfFile;
             m_earliestSeekablePosition = append ? m_length : 0;
             m_accessMask = fileInfo.AccessInformation.AccessFlags;
+
+            m_position = m_earliestSeekablePosition;
+            m_disposed = false;
         }
 
         public override void Flush()

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -31,7 +31,7 @@ namespace SMBLibrary.Client
                 { FileOptions.WriteThrough, CreateOptions.FILE_WRITE_THROUGH },
                 { FileOptions.DeleteOnClose, CreateOptions.FILE_DELETE_ON_CLOSE },
                 //{ FileOptions.SequentialScan, CreateOptions.FILE_SEQUENTIAL_ONLY },
-                //{ FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
+                { FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
                 //{ FileOptions.Asynchronous, CreateOptions. },
             };
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -5,6 +5,9 @@ namespace SMBLibrary.Client
 {
     public sealed class SMBFileStream : Stream
     {
+        private const AccessMask FileReadData = (AccessMask)0x01;
+        private const AccessMask FileWriteData = (AccessMask)0x02;
+
         public override bool CanRead => throw new NotImplementedException();
 
         public override bool CanWrite => throw new NotImplementedException();

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -10,6 +10,8 @@ namespace SMBLibrary.Client
         private const AccessMask FileReadData = (AccessMask)0x01;
         private const AccessMask FileWriteData = (AccessMask)0x02;
 
+        private const ShareAccess SupportedShareAccessFlags = ShareAccess.Read | ShareAccess.Write | ShareAccess.Delete;
+
         private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
 
         private static readonly Dictionary<FileMode, CreateDisposition> _fileModeToCreateDispositionMap =
@@ -79,7 +81,7 @@ namespace SMBLibrary.Client
 
             var fileAttributes = (FileAttributes)0; //TODO
 
-            var shareAccess = (ShareAccess)0; //TODO
+            var shareAccess = (ShareAccess)fileShare & SupportedShareAccessFlags;
 
             var createDisposition = _fileModeToCreateDispositionMap[fileMode];
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -41,14 +41,14 @@ namespace SMBLibrary.Client
             }
             catch (Exception e)
             {
-                throw new ArgumentException($"Invalid file information class: {typeof(T)}", e);
+                throw new ArgumentException($"Invalid file information class: {typeof(T)}.", e);
             }
 
             var status = store.GetFileInformation(out var result, handle, fileInformationClass);
 
             return status == NTStatus.STATUS_SUCCESS
                 ? (T)result
-                : throw new IOException($"Could not get file information from SMB file. Error status: {status}");
+                : throw new IOException($"Could not get file information from SMB file. Error status: {status}.");
         }
 
         public override bool CanRead => !m_disposed && (m_accessMask & AccessMask.FILE_READ_DATA) != 0;
@@ -148,17 +148,17 @@ namespace SMBLibrary.Client
                 throw new ArgumentNullException(nameof(path));
 
             if (Path.IsPathRooted(path))
-                throw new ArgumentException("Path must be relative", nameof(path));
+                throw new ArgumentException("Path must be relative.", nameof(path));
 
             var append = fileMode == FileMode.Append;
 
             if (append || fileMode == FileMode.Truncate)
             {
                 if ((fileAccess & FileAccess.Read) != 0)
-                    throw new ArgumentException($"{fileMode} cannot be combined with FileAccess.Read");
+                    throw new ArgumentException($"{fileMode} cannot be combined with FileAccess.Read.");
 
                 if ((fileAccess & FileAccess.Write) == 0)
-                    throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write");
+                    throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write.");
             }
 
             var accessMask = AccessMask.FILE_READ_ATTRIBUTES;
@@ -222,7 +222,7 @@ namespace SMBLibrary.Client
             try
             {
                 if (status != NTStatus.STATUS_SUCCESS)
-                    throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
+                    throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}.");
 
                 var fileInfo = GetFileInformation<FileAllInformation>(store, handle);
 
@@ -252,7 +252,7 @@ namespace SMBLibrary.Client
             var status = Store.FlushFileBuffers(m_handle);
 
             if (status != NTStatus.STATUS_SUCCESS)
-                throw new IOException($"Could not flush SMB stream. Error status: {status}");
+                throw new IOException($"Could not flush SMB stream. Error status: {status}.");
         }
 
         public override void SetLength(long value)
@@ -270,7 +270,7 @@ namespace SMBLibrary.Client
             var status = Store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
 
             if (status != NTStatus.STATUS_SUCCESS)
-                throw new IOException($"Could not set file length. Error status: {status}");
+                throw new IOException($"Could not set file length. Error status: {status}.");
 
             m_length = value;
 
@@ -388,11 +388,11 @@ namespace SMBLibrary.Client
 
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException(
-                        $"Could not write to SMB file. Bytes successfully written: {written}. Error status: {status}");
+                        $"Could not write to SMB file. Bytes successfully written: {written}. Error status: {status}.");
 
                 if (writtenThisRound == 0)
                     throw new IOException(
-                        $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}");
+                        $"SMB server reported a successful write of zero bytes. Bytes successfully written: {written}.");
 
                 written += writtenThisRound;
                 m_length = Math.Max(m_length, m_position + written);

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -89,7 +89,15 @@ namespace SMBLibrary.Client
                 if ((fileOptions & entry.Key) != FileOptions.None)
                     createOptions |= entry.Value;
 
-            throw new NotImplementedException();
+            var status = store.CreateFile(out var handle, out var fileStatus, path, accessMask, fileAttributes,
+                shareAccess, createDisposition, createOptions, null);
+
+            if (status != NTStatus.STATUS_SUCCESS)
+                throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
+
+            m_handle = handle;
+            m_store = store;
+            m_disposed = false;
         }
 
         public override void Flush()

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -265,6 +265,8 @@ namespace SMBLibrary.Client
             }
 
             throw new NotImplementedException();
+
+            m_position += count;
         }
 
         protected override void Dispose(bool disposeManaged)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -90,7 +90,7 @@ namespace SMBLibrary.Client
         /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
         /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
         /// <param name="fileOptions">TODO Default <see cref="FileOptions.None"/></param>
-        /// <param name="ownsStore">TODO Default: false</param>
+        /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>
         /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/>> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>
         /// <exception cref="InvalidEnumArgumentException"><paramref name="fileMode"/> contains an invalid value.</exception>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -15,13 +15,6 @@ namespace SMBLibrary.Client
 
         private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
 
-        private static readonly Dictionary<FileAccess, AccessMask> FileAccessToAccessMaskMap =
-            new Dictionary<FileAccess, AccessMask>(2)
-            {
-                { FileAccess.Read, AccessMask.FILE_READ_DATA },
-                { FileAccess.Write, AccessMask.FILE_WRITE_DATA },
-            };
-
         private static readonly Dictionary<FileOptions, CreateOptions> FileOptionsToCreateOptionsMap =
             new Dictionary<FileOptions, CreateOptions>(4)
             {
@@ -161,14 +154,10 @@ namespace SMBLibrary.Client
                     throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write.");
             }
 
-            var accessMask = AccessMask.FILE_READ_ATTRIBUTES;
+            var accessMask = (AccessMask)(fileAccess & FileAccess.ReadWrite) | AccessMask.FILE_READ_ATTRIBUTES;
 
             if (append)
                 accessMask |= AccessMask.FILE_APPEND_DATA;
-
-            foreach (var entry in FileAccessToAccessMaskMap)
-                if ((fileAccess & entry.Key) != 0)
-                    accessMask |= entry.Value;
 
             //Possibly replace this with commented code below
             const FileAttributes fileAttributes = FileAttributes.Normal;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -252,7 +252,7 @@ namespace SMBLibrary.Client
 
             var maxWriteSize = MaxWriteSize;
 
-            if (source.Length > MaxWriteSize)
+            if (source.Length > maxWriteSize)
                 throw new IOException($"Write size exceeds maximum write size of {maxWriteSize} bytes.");
 
             byte[] data;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -103,9 +103,14 @@ namespace SMBLibrary.Client
                 if ((fileAccess & entry.Key) != 0)
                     accessMask |= entry.Value;
 
+            //Possibly replace this with commented code below
+            const FileAttributes fileAttributes = FileAttributes.Normal;
+
+            /*
             var fileAttributes = (fileOptions & FileOptions.Encrypted) != FileOptions.None
                 ? FileAttributes.Encrypted
                 : FileAttributes.Normal;
+            //*/
 
             var shareAccess = (ShareAccess)fileShare & SupportedShareAccessFlags;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -102,7 +102,10 @@ namespace SMBLibrary.Client
                     throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write");
             }
 
-            var accessMask = append ? AccessMask.FILE_APPEND_DATA : 0;
+            var accessMask = AccessMask.FILE_READ_ATTRIBUTES;
+
+            if (append)
+                accessMask |= AccessMask.FILE_APPEND_DATA;
 
             foreach (var entry in FileAccessToAccessMaskMap)
                 if ((fileAccess & entry.Key) != 0)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -146,7 +146,10 @@ namespace SMBLibrary.Client
 
             var status = m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
 
-            if (status == NTStatus.STATUS_SUCCESS && m_position > value)
+            if (status != NTStatus.STATUS_SUCCESS)
+                throw new IOException($"Could not set file length. Error status: {status}");
+
+            if (m_position > value)
                 m_position = value;
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace SMBLibrary.Client
+{
+    public sealed class SMBFileStream : Stream
+    {
+        public override bool CanRead => throw new NotImplementedException();
+
+        public override bool CanWrite => throw new NotImplementedException();
+
+        public override bool CanSeek => throw new NotImplementedException();
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override void Flush() => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+    }
+}

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -99,19 +99,22 @@ namespace SMBLibrary.Client
             if (ownsStore && !ownsHandle)
                 throw new ArgumentException("A stream that owns the store must also own the handle.");
 
-            var fileInfo = GetFileInformation<FileAllInformation>(store, handle);
+            var standardInfo = GetFileInformation<FileStandardInformation>(store, handle);
 
-            if (fileInfo.StandardInformation.Directory)
+            if (standardInfo.Directory)
                 throw new ArgumentException("Cannot construct a stream with a directory handle.", nameof(handle));
 
-            Name = fileInfo.NameInformation.FileName;
+            var nameInfo = GetFileInformation<FileAlternateNameInformation>(store, handle);
+            var accessInfo = GetFileInformation<FileAccessInformation>(store, handle);
+
+            Name = nameInfo.FileName;
             Store = store;
             m_handle = handle;
             m_ownsHandle = ownsHandle;
             m_ownsStore = ownsStore;
             m_earliestSeekablePosition = 0;
-            m_accessMask = fileInfo.AccessInformation.AccessFlags;
-            m_length = fileInfo.StandardInformation.EndOfFile;
+            m_accessMask = accessInfo.AccessFlags;
+            m_length = standardInfo.EndOfFile;
             m_position = m_earliestSeekablePosition;
             m_disposed = false;
         }
@@ -156,7 +159,7 @@ namespace SMBLibrary.Client
 
             //FILE_APPEND_DATA is not requested even when fileMode == FileMode.Append because
             //the stream will enforce append constraints by itself.
-            var accessMask = (AccessMask)(fileAccess & FileAccess.ReadWrite) | AccessMask.FILE_READ_ATTRIBUTES;
+            var accessMask = (AccessMask)(fileAccess & FileAccess.ReadWrite);
 
             //Possibly replace this with commented code below
             const FileAttributes fileAttributes = FileAttributes.Normal;
@@ -212,16 +215,18 @@ namespace SMBLibrary.Client
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}.");
 
-                var fileInfo = GetFileInformation<FileAllInformation>(store, handle);
+                var nameInfo = GetFileInformation<FileAlternateNameInformation>(store, handle);
+                var standardInfo = GetFileInformation<FileStandardInformation>(store, handle);
+                var accessInfo = GetFileInformation<FileAccessInformation>(store, handle);
 
-                Name = fileInfo.NameInformation.FileName;
+                Name = nameInfo.FileName;
                 Store = store;
                 m_handle = handle;
                 m_ownsHandle = true;
                 m_ownsStore = ownsStore;
-                m_length = fileInfo.StandardInformation.EndOfFile;
+                m_length = standardInfo.EndOfFile;
                 m_earliestSeekablePosition = append ? m_length : 0;
-                m_accessMask = fileInfo.AccessInformation.AccessFlags;
+                m_accessMask = accessInfo.AccessFlags;
                 m_position = m_earliestSeekablePosition;
                 m_disposed = false;
             }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -79,6 +79,9 @@ namespace SMBLibrary.Client
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
 
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentNullException(nameof(path));
+
             if (Path.IsPathRooted(path))
                 throw new ArgumentException("Path must be relative", nameof(path));
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -217,9 +217,6 @@ namespace SMBLibrary.Client
             if (target < m_earliestSeekablePosition)
                 throw new IOException("Cannot seek before beginning of stream.");
 
-            if (target > m_length)
-                throw new IOException("Cannot seek past end of stream.");
-
             m_position = target;
             return m_position;
         }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -97,29 +97,18 @@ namespace SMBLibrary.Client
             if (Path.IsPathRooted(path))
                 throw new ArgumentException("Path must be relative", nameof(path));
 
-            if (fileMode == FileMode.Truncate)
+            var append = fileMode == FileMode.Append;
+
+            if (append || fileMode == FileMode.Truncate)
             {
                 if ((fileAccess & FileAccess.Read) != 0)
-                    throw new ArgumentException("FileMode.Truncate cannot be combined with FileAccess.Read");
+                    throw new ArgumentException($"{fileMode} cannot be combined with FileAccess.Read");
 
                 if ((fileAccess & FileAccess.Write) == 0)
-                    throw new ArgumentException("FileMode.Truncate must be combined with FileAccess.Write");
-
-                //TODO: throw FileNotFoundException if file does not exist
+                    throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write");
             }
 
-            var accessMask = (AccessMask)0;
-
-            if (fileMode == FileMode.Append)
-            {
-                if ((fileAccess & FileAccess.Read) != 0)
-                    throw new ArgumentException("FileMode.Append cannot be combined with FileAccess.Read");
-
-                if ((fileAccess & FileAccess.Write) == 0)
-                    throw new ArgumentException("FileMode.Append must be combined with FileAccess.Write");
-
-                accessMask |= FileAppendData;
-            }
+            var accessMask = append ? FileAppendData : 0;
 
             foreach (var entry in FileAccessToAccessMaskMap)
                 if ((fileAccess & entry.Key) != 0)
@@ -154,7 +143,7 @@ namespace SMBLibrary.Client
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;
             m_length = GetFileInformation<FileStandardInformation>().EndOfFile;
-            m_earliestSeekablePosition = fileMode == FileMode.Append ? m_length : 0;
+            m_earliestSeekablePosition = append ? m_length : 0;
             m_accessMask = GetFileInformation<FileAccessInformation>().AccessFlags;
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -104,7 +104,7 @@ namespace SMBLibrary.Client
             if (standardInfo.Directory)
                 throw new ArgumentException("Cannot construct a stream with a directory handle.", nameof(handle));
 
-            var nameInfo = GetFileInformation<FileAlternateNameInformation>(store, handle);
+            var nameInfo = GetFileInformation<FileNameInformation>(store, handle);
             var accessInfo = GetFileInformation<FileAccessInformation>(store, handle);
 
             Name = nameInfo.FileName;
@@ -215,7 +215,7 @@ namespace SMBLibrary.Client
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}.");
 
-                var nameInfo = GetFileInformation<FileAlternateNameInformation>(store, handle);
+                var nameInfo = GetFileInformation<FileNameInformation>(store, handle);
                 var standardInfo = GetFileInformation<FileStandardInformation>(store, handle);
                 var accessInfo = GetFileInformation<FileAccessInformation>(store, handle);
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -87,7 +87,7 @@ namespace SMBLibrary.Client
         /// <param name="store">TODO</param>
         /// <param name="path">A relative path to the file that the stream will encapsulate.</param>
         /// <param name="fileMode">One of the enumeration values that determines how to open or create the file.</param>
-        /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
+        /// <param name="fileAccess">A bitwise combination of the enumeration values that determines how the file can be accessed by the stream. Default: <see cref="FileAccess.ReadWrite"/></param>
         /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
         /// <param name="fileOptions">A bitwise combination of the enumeration values that specifies additional file options. Default: <see cref="FileOptions.None"/></param>
         /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -91,10 +91,10 @@ namespace SMBLibrary.Client
         /// <param name="fileShare">TODO</param>
         /// <param name="fileOptions">TODO</param>
         /// <param name="ownsStore">TODO</param>
-        /// <exception cref="ArgumentNullException">TODO</exception>
-        /// <exception cref="ArgumentException">TODO</exception>
-        /// <exception cref="InvalidEnumArgumentException">TODO</exception>
-        /// <exception cref="IOException">TODO</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/>> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>
+        /// <exception cref="InvalidEnumArgumentException"><paramref name="fileMode"/> contains an invalid value.</exception>
+        /// <exception cref="IOException">An error occured while attempting to either create the file handle or read its information.</exception>
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
             FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,
             FileOptions fileOptions = FileOptions.None, bool ownsStore = false)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -286,7 +286,8 @@ namespace SMBLibrary.Client
             {
                 var status = Store.ReadFile(out var bytes, m_handle, m_position + read, maxBytes - read);
 
-                if ((status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE) || bytes.Length == 0)
+                if ((status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE) ||
+                    bytes == null || bytes.Length == 0)
                     break;
 
                 Array.Copy(bytes, 0, destination, offset + read, bytes.Length);

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -141,10 +141,18 @@ namespace SMBLibrary.Client
             m_position = m_earliestSeekablePosition;
             m_disposed = false;
 
-            Name = GetFileInformation<FileAlternateNameInformation>().FileName;
-            m_length = GetFileInformation<FileStandardInformation>().EndOfFile;
+            var result = m_store.GetFileInformation(out var info, m_handle,
+                FileInformationClass.FileAllInformation);
+
+            if (result != NTStatus.STATUS_SUCCESS)
+                throw new IOException($"Could not get file information from SMB file. Error status: {status}");
+
+            var fileInfo = (FileAllInformation)info;
+
+            Name = fileInfo.NameInformation.FileName;
+            m_length = fileInfo.StandardInformation.EndOfFile;
             m_earliestSeekablePosition = append ? m_length : 0;
-            m_accessMask = GetFileInformation<FileAccessInformation>().AccessFlags;
+            m_accessMask = fileInfo.AccessInformation.AccessFlags;
         }
 
         public override void Flush()
@@ -330,7 +338,7 @@ namespace SMBLibrary.Client
 
             base.Dispose(disposeManaged);
         }
-
+        /*
         private T GetFileInformation<T>() where T : FileInformation
         {
             if (m_disposed)
@@ -353,5 +361,6 @@ namespace SMBLibrary.Client
                 ? (T)result
                 : throw new IOException($"Could not get file information from SMB file. Error status: {status}");
         }
+        //*/
     }
 }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -38,7 +38,7 @@ namespace SMBLibrary.Client
             {
                 { FileOptions.WriteThrough, CreateOptions.FILE_WRITE_THROUGH },
                 { FileOptions.DeleteOnClose, CreateOptions.FILE_DELETE_ON_CLOSE },
-                //{ FileOptions.SequentialScan, CreateOptions.FILE_SEQUENTIAL_ONLY },
+                { FileOptions.SequentialScan, CreateOptions.FILE_SEQUENTIAL_ONLY },
                 { FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
             };
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -253,18 +253,20 @@ namespace SMBLibrary.Client
             if (!CanWrite)
                 throw new NotSupportedException();
 
-            byte[] data;
+            var written = 0;
 
-            if (offset == 0 && count == source.Length)
-                data = source;
-
-            else
+            while (written < count)
             {
-                data = new byte[count];
-                Array.Copy(source, offset, data, 0, count);
-            }
+                var bytes = new byte[Math.Min(MaxWriteSize, count - written)];
+                Array.Copy(source, offset + written, bytes, 0, bytes.Length);
+                var status = m_store.WriteFile(out var writtenThisRound, m_handle, m_position + written, bytes);
 
-            throw new NotImplementedException();
+                if (status != NTStatus.STATUS_SUCCESS)
+                    throw new IOException(
+                        $"Could not write to SMB file. Bytes successfully written: {written}. Error status: {status}");
+
+                written += writtenThisRound;
+            }
 
             m_position += count;
         }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -102,7 +102,7 @@ namespace SMBLibrary.Client
                 if ((fileAccess & entry.Key) != 0)
                     accessMask |= entry.Value;
 
-            var fileAttributes = (fileOptions & FileOptions.Encrypted) != 0
+            var fileAttributes = (fileOptions & FileOptions.Encrypted) != FileOptions.None
                 ? FileAttributes.Encrypted
                 : FileAttributes.Normal;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary.Client
 
         private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
 
-        private static readonly Dictionary<FileMode, CreateDisposition> _fileModeToCreateDispositionMap =
+        private static readonly Dictionary<FileMode, CreateDisposition> FileModeToCreateDispositionMap =
             new Dictionary<FileMode, CreateDisposition>(6)
             {
                 { FileMode.CreateNew, CreateDisposition.FILE_CREATE },
@@ -25,7 +25,7 @@ namespace SMBLibrary.Client
                 { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
             };
 
-        private static readonly Dictionary<FileOptions, CreateOptions> _fileOptionsToCreateOptionsMap =
+        private static readonly Dictionary<FileOptions, CreateOptions> FileOptionsToCreateOptionsMap =
             new Dictionary<FileOptions, CreateOptions>(5)
             {
                 { FileOptions.WriteThrough, CreateOptions.FILE_WRITE_THROUGH },
@@ -83,11 +83,11 @@ namespace SMBLibrary.Client
 
             var shareAccess = (ShareAccess)fileShare & SupportedShareAccessFlags;
 
-            var createDisposition = _fileModeToCreateDispositionMap[fileMode];
+            var createDisposition = FileModeToCreateDispositionMap[fileMode];
 
             var createOptions = RequiredCreateFlags;
 
-            foreach (var entry in _fileOptionsToCreateOptionsMap)
+            foreach (var entry in FileOptionsToCreateOptionsMap)
                 if ((fileOptions & entry.Key) != FileOptions.None)
                     createOptions |= entry.Value;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -124,6 +124,8 @@ namespace SMBLibrary.Client
             m_handle = handle;
             m_ownsStore = ownsStore;
             m_store = store;
+
+            m_position = 0;
             m_disposed = false;
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -9,6 +9,7 @@ namespace SMBLibrary.Client
     {
         private const AccessMask FileReadData = (AccessMask)0x01;
         private const AccessMask FileWriteData = (AccessMask)0x02;
+        private const AccessMask FileAppendData = (AccessMask)0x04;
 
         private const ShareAccess SupportedShareAccessFlags = ShareAccess.Read | ShareAccess.Write | ShareAccess.Delete;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -19,7 +19,7 @@ namespace SMBLibrary.Client
                 { FileMode.Create, CreateDisposition.FILE_SUPERSEDE },
                 { FileMode.Open, CreateDisposition.FILE_OPEN },
                 { FileMode.OpenOrCreate, CreateDisposition.FILE_OPEN_IF },
-                //{ FileMode.Truncate, CreateDisposition. },
+                { FileMode.Truncate, CreateDisposition.FILE_SUPERSEDE },
                 { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
             };
 
@@ -69,6 +69,11 @@ namespace SMBLibrary.Client
 
             if (Path.IsPathRooted(path))
                 throw new ArgumentException("Path must be relative", nameof(path));
+
+            if (fileMode == FileMode.Truncate)
+            {
+                //TODO: throw FileNotFoundException if file does not exist
+            }
 
             throw new NotImplementedException();
         }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -92,7 +92,7 @@ namespace SMBLibrary.Client
         /// <param name="fileOptions">A bitwise combination of the enumeration values that specifies additional file options. Default: <see cref="FileOptions.None"/></param>
         /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>
         /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>
-        /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/>> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>
         /// <exception cref="InvalidEnumArgumentException"><paramref name="fileMode"/> contains an invalid value.</exception>
         /// <exception cref="IOException">An error occured while attempting to either create the file handle or read its information.</exception>
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -79,6 +79,7 @@ namespace SMBLibrary.Client
 
         private readonly object m_handle;
         private readonly bool m_ownsStore;
+        private readonly long m_earliestSeekablePosition;
         private readonly AccessMask m_accessMask;
         private readonly ISMBFileStore m_store;
 
@@ -145,9 +146,11 @@ namespace SMBLibrary.Client
 
             m_handle = handle;
             m_ownsStore = ownsStore;
+            m_earliestSeekablePosition =
+                fileMode == FileMode.Append ? GetFileInformation<FileStandardInformation>().EndOfFile : 0;
             m_store = store;
 
-            m_position = 0;
+            m_position = m_earliestSeekablePosition;
             m_disposed = false;
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;
@@ -173,8 +176,9 @@ namespace SMBLibrary.Client
             if (!CanWrite)
                 throw new NotSupportedException();
 
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), "The length of the file must be 0 or greater.");
+            if (value < m_earliestSeekablePosition)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"The length of the file must be {m_earliestSeekablePosition} or greater.");
 
             var status = m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
 
@@ -208,7 +212,7 @@ namespace SMBLibrary.Client
                     throw new InvalidEnumArgumentException(nameof(origin), (int)origin, typeof(SeekOrigin));
             }
 
-            if (target < 0)
+            if (target < m_earliestSeekablePosition)
                 throw new IOException("Cannot seek before beginning of stream.");
 
             if (target > length)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.IO;
 
 namespace SMBLibrary.Client
@@ -12,14 +13,14 @@ namespace SMBLibrary.Client
 
         public override bool CanWrite => !m_disposed && (AccessMask & FileWriteData) != 0;
 
-        public override bool CanSeek => throw new NotImplementedException();
+        public override bool CanSeek => !m_disposed;
 
         public override long Length => GetFileInformation<FileStandardInformation>().EndOfFile;
 
         public override long Position
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get => GetFileInformation<FilePositionInformation>().CurrentByteOffset;
+            set => Seek(value, SeekOrigin.Begin);
         }
 
         public string Name => GetFileInformation<FileAlternateNameInformation>().FileName;
@@ -39,9 +40,55 @@ namespace SMBLibrary.Client
             m_store.FlushFileBuffers(m_handle);
         }
 
-        public override void SetLength(long value) => throw new NotImplementedException();
+        public override void SetLength(long value)
+        {
+            if (m_disposed)
+                throw new ObjectDisposedException(nameof(SMBFileStream));
 
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+            if (!CanWrite)
+                throw new NotSupportedException();
+
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value), "The length of the file must be 0 or greater.");
+
+            m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var length = Length;
+            var target = offset;
+
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    // Do nothing
+                    break;
+
+                case SeekOrigin.Current:
+                    target += Position;
+                    break;
+
+                case SeekOrigin.End:
+                    target += length;
+                    break;
+
+                default:
+                    throw new InvalidEnumArgumentException(nameof(origin), (int)origin, typeof(SeekOrigin));
+            }
+
+            if (target < 0)
+                throw new IOException("Cannot seek before beginning of stream.");
+
+            if (target > length)
+                throw new IOException("Cannot seek past end of stream.");
+
+            var result = m_store.SetFileInformation(m_handle, new FilePositionInformation { CurrentByteOffset = target });
+
+            return result == NTStatus.STATUS_SUCCESS
+                ? target
+                : throw new IOException($"Could not set SMB file position. Error status: {result}");
+        }
 
         public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -328,10 +328,15 @@ namespace SMBLibrary.Client
 
             if (disposeManaged)
             {
-                m_store.CloseFile(m_handle);
-
-                if (m_ownsStore)
-                    m_store.Disconnect();
+                try
+                {
+                    m_store.CloseFile(m_handle);
+                }
+                finally
+                {
+                    if (m_ownsStore)
+                        m_store.Disconnect();
+                }
             }
 
             base.Dispose(disposeManaged);

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -75,6 +75,12 @@ namespace SMBLibrary.Client
                 //TODO: throw FileNotFoundException if file does not exist
             }
 
+            var accessMask = (AccessMask)0; //TODO
+
+            var fileAttributes = (FileAttributes)0; //TODO
+
+            var shareAccess = (ShareAccess)0; //TODO
+
             var createDisposition = _fileModeToCreateDispositionMap[fileMode];
 
             var createOptions = RequiredCreateFlags;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -6,7 +6,7 @@ using System.IO;
 namespace SMBLibrary.Client
 {
     /// <summary>
-    /// TODO a single SMB-shared file.
+    /// Provides a <see cref="Stream"/> for a single SMB-shared file.
     /// This class cannot be inherited.
     /// </summary>
     public sealed class SMBFileStream : Stream

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -58,13 +58,14 @@ namespace SMBLibrary.Client
         private AccessMask AccessMask => GetFileInformation<FileAccessInformation>().AccessFlags;
 
         private readonly object m_handle;
+        private readonly bool m_ownsStore;
         private readonly ISMBFileStore m_store;
 
         private bool m_disposed;
 
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
             FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,
-            FileOptions fileOptions = FileOptions.None)
+            FileOptions fileOptions = FileOptions.None, bool ownsStore = false)
         {
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
@@ -98,6 +99,7 @@ namespace SMBLibrary.Client
                 throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
 
             m_handle = handle;
+            m_ownsStore = ownsStore;
             m_store = store;
             m_disposed = false;
         }
@@ -244,7 +246,12 @@ namespace SMBLibrary.Client
             m_disposed = true;
 
             if (disposeManaged)
+            {
                 m_store.CloseFile(m_handle);
+
+                if (m_ownsStore)
+                    m_store.Disconnect();
+            }
 
             base.Dispose(disposeManaged);
         }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -6,7 +6,8 @@ using System.IO;
 namespace SMBLibrary.Client
 {
     /// <summary>
-    /// TODO
+    /// TODO a single SMB-shared file.
+    /// This class cannot be inherited.
     /// </summary>
     public sealed class SMBFileStream : Stream
     {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -89,7 +89,7 @@ namespace SMBLibrary.Client
         /// <param name="fileMode">TODO</param>
         /// <param name="fileAccess">TODO Default: <see cref="FileAccess.ReadWrite"/></param>
         /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
-        /// <param name="fileOptions">TODO Default <see cref="FileOptions.None"/></param>
+        /// <param name="fileOptions">A bitwise combination of the enumeration values that specifies additional file options. Default: <see cref="FileOptions.None"/></param>
         /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>
         /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>
         /// <exception cref="ArgumentException"><paramref name="path"/> is an absolute path, or <paramref name="fileMode"/> is <see cref="FileMode.Append"/> or <see cref="FileMode.Truncate"/>> while <paramref name="fileAccess"/> is not <see cref="FileAccess.Write"/>.</exception>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -129,7 +129,7 @@ namespace SMBLibrary.Client
         public override void Flush()
         {
             if (m_disposed)
-                throw new ObjectDisposedException(nameof(SMBFileStream));
+                throw new ObjectDisposedException(GetType().FullName);
 
             m_store.FlushFileBuffers(m_handle);
         }
@@ -137,7 +137,7 @@ namespace SMBLibrary.Client
         public override void SetLength(long value)
         {
             if (m_disposed)
-                throw new ObjectDisposedException(nameof(SMBFileStream));
+                throw new ObjectDisposedException(GetType().FullName);
 
             if (!CanWrite)
                 throw new NotSupportedException();
@@ -187,7 +187,7 @@ namespace SMBLibrary.Client
         public override int Read(byte[] destination, int offset, int count)
         {
             if (m_disposed)
-                throw new ObjectDisposedException(nameof(SMBFileStream));
+                throw new ObjectDisposedException(GetType().FullName);
 
             if (count == 0)
                 return 0;
@@ -232,7 +232,7 @@ namespace SMBLibrary.Client
         public override void Write(byte[] source, int offset, int count)
         {
             if (m_disposed)
-                throw new ObjectDisposedException(nameof(SMBFileStream));
+                throw new ObjectDisposedException(GetType().FullName);
 
             if (count == 0)
                 return;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -179,12 +179,7 @@ namespace SMBLibrary.Client
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not create SMB handle. Error status: {status}. File status: {fileStatus}");
 
-                Store = store;
-                m_handle = handle;
-                m_ownsStore = ownsStore;
-
-                status = Store.GetFileInformation(out var info, m_handle,
-                    FileInformationClass.FileAllInformation);
+                status = store.GetFileInformation(out var info, handle, FileInformationClass.FileAllInformation);
 
                 if (status != NTStatus.STATUS_SUCCESS)
                     throw new IOException($"Could not get file information from SMB file. Error status: {status}");
@@ -192,10 +187,12 @@ namespace SMBLibrary.Client
                 var fileInfo = (FileAllInformation)info;
 
                 Name = fileInfo.NameInformation.FileName;
+                Store = store;
+                m_handle = handle;
+                m_ownsStore = ownsStore;
                 m_length = fileInfo.StandardInformation.EndOfFile;
                 m_earliestSeekablePosition = append ? m_length : 0;
                 m_accessMask = fileInfo.AccessInformation.AccessFlags;
-
                 m_position = m_earliestSeekablePosition;
                 m_disposed = false;
             }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -75,6 +75,14 @@ namespace SMBLibrary.Client
                 //TODO: throw FileNotFoundException if file does not exist
             }
 
+            var createDisposition = _fileModeToCreateDispositionMap[fileMode];
+
+            var createOptions = RequiredCreateFlags;
+
+            foreach (var entry in _fileOptionsToCreateOptionsMap)
+                if ((fileOptions & entry.Key) != FileOptions.None)
+                    createOptions |= entry.Value;
+
             throw new NotImplementedException();
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -76,6 +76,7 @@ namespace SMBLibrary.Client
         public ISMBFileStore Store { get; }
 
         private readonly object m_handle;
+        private readonly bool m_ownsHandle;
         private readonly bool m_ownsStore;
         private readonly long m_earliestSeekablePosition;
         private readonly AccessMask m_accessMask;
@@ -190,6 +191,7 @@ namespace SMBLibrary.Client
                 Name = fileInfo.NameInformation.FileName;
                 Store = store;
                 m_handle = handle;
+                m_ownsHandle = true;
                 m_ownsStore = ownsStore;
                 m_length = fileInfo.StandardInformation.EndOfFile;
                 m_earliestSeekablePosition = append ? m_length : 0;
@@ -372,7 +374,8 @@ namespace SMBLibrary.Client
             {
                 try
                 {
-                    Store.CloseFile(m_handle);
+                    if (m_ownsHandle)
+                        Store.CloseFile(m_handle);
                 }
                 finally
                 {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -88,7 +88,7 @@ namespace SMBLibrary.Client
         /// <param name="path">A relative path to the file that the stream will encapsulate.</param>
         /// <param name="fileMode">One of the enumeration values that determines how to open or create the file.</param>
         /// <param name="fileAccess">A bitwise combination of the enumeration values that determines how the file can be accessed by the stream. Default: <see cref="FileAccess.ReadWrite"/></param>
-        /// <param name="fileShare">TODO Default: <see cref="FileShare.Read"/></param>
+        /// <param name="fileShare">A bitwise combination of the enumeration values that determines how the file will be shared by processes. Default: <see cref="FileShare.Read"/></param>
         /// <param name="fileOptions">A bitwise combination of the enumeration values that specifies additional file options. Default: <see cref="FileOptions.None"/></param>
         /// <param name="ownsStore">True to disconnect <paramref name="store"/> when the stream is disposed; otherwise, false. Default: false</param>
         /// <exception cref="ArgumentNullException"><paramref name="store"/> is null, or <paramref name="path"/> is null or an empty string.</exception>

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -29,7 +29,7 @@ namespace SMBLibrary.Client
                 { FileMode.Create, CreateDisposition.FILE_SUPERSEDE },
                 { FileMode.Open, CreateDisposition.FILE_OPEN },
                 { FileMode.OpenOrCreate, CreateDisposition.FILE_OPEN_IF },
-                { FileMode.Truncate, CreateDisposition.FILE_SUPERSEDE },
+                { FileMode.Truncate, CreateDisposition.FILE_OVERWRITE },
                 { FileMode.Append, CreateDisposition.FILE_OPEN_IF },
             };
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -19,6 +19,8 @@ namespace SMBLibrary.Client
             set => throw new NotImplementedException();
         }
 
+        private bool m_disposed;
+
         public override void Flush() => throw new NotImplementedException();
 
         public override void SetLength(long value) => throw new NotImplementedException();
@@ -28,5 +30,15 @@ namespace SMBLibrary.Client
         public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        protected override void Dispose(bool disposeManaged)
+        {
+            if (m_disposed)
+                return;
+
+            m_disposed = true;
+
+            base.Dispose(disposeManaged);
+        }
     }
 }

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -68,7 +68,7 @@ namespace SMBLibrary.Client
         public string Name { get; }
 
         /// <summary>
-        /// TODO
+        /// The <see cref="ISMBFileStore"/> with which this stream was created.
         /// </summary>
         public ISMBFileStore Store { get; }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -57,6 +57,20 @@ namespace SMBLibrary.Client
             set => Seek(value, SeekOrigin.Begin);
         }
 
+        public override bool CanTimeout => false;
+
+        public override int ReadTimeout
+        {
+            get => throw new InvalidOperationException();
+            set => throw new InvalidOperationException();
+        }
+
+        public override int WriteTimeout
+        {
+            get => throw new InvalidOperationException();
+            set => throw new InvalidOperationException();
+        }
+
         public int MaxReadSize => (int)Math.Min(int.MaxValue, m_store.MaxReadSize);
 
         public int MaxWriteSize => (int)Math.Min(int.MaxValue, m_store.MaxWriteSize);

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -10,6 +10,8 @@ namespace SMBLibrary.Client
         private const AccessMask FileReadData = (AccessMask)0x01;
         private const AccessMask FileWriteData = (AccessMask)0x02;
 
+        private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
+
         private static readonly Dictionary<FileMode, CreateDisposition> _fileModeToCreateDispositionMap =
             new Dictionary<FileMode, CreateDisposition>(6)
             {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -11,10 +11,6 @@ namespace SMBLibrary.Client
     /// </summary>
     public sealed class SMBFileStream : Stream
     {
-        private const AccessMask FileReadData = (AccessMask)0x01;
-        private const AccessMask FileWriteData = (AccessMask)0x02;
-        private const AccessMask FileAppendData = (AccessMask)0x04;
-
         private const ShareAccess SupportedShareAccessFlags = ShareAccess.Read | ShareAccess.Write | ShareAccess.Delete;
 
         private const CreateOptions RequiredCreateFlags = CreateOptions.FILE_NON_DIRECTORY_FILE;
@@ -22,8 +18,8 @@ namespace SMBLibrary.Client
         private static readonly Dictionary<FileAccess, AccessMask> FileAccessToAccessMaskMap =
             new Dictionary<FileAccess, AccessMask>(2)
             {
-                { FileAccess.Read, FileReadData },
-                { FileAccess.Write, FileWriteData },
+                { FileAccess.Read, AccessMask.FILE_READ_DATA },
+                { FileAccess.Write, AccessMask.FILE_WRITE_DATA },
             };
 
         private static readonly Dictionary<FileOptions, CreateOptions> FileOptionsToCreateOptionsMap =
@@ -35,9 +31,9 @@ namespace SMBLibrary.Client
                 { FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
             };
 
-        public override bool CanRead => !m_disposed && (m_accessMask & FileReadData) != 0;
+        public override bool CanRead => !m_disposed && (m_accessMask & AccessMask.FILE_READ_DATA) != 0;
 
-        public override bool CanWrite => !m_disposed && (m_accessMask & FileWriteData) != 0;
+        public override bool CanWrite => !m_disposed && (m_accessMask & AccessMask.FILE_WRITE_DATA) != 0;
 
         public override bool CanSeek => !m_disposed;
 
@@ -106,7 +102,7 @@ namespace SMBLibrary.Client
                     throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write");
             }
 
-            var accessMask = append ? FileAppendData : 0;
+            var accessMask = append ? AccessMask.FILE_APPEND_DATA : 0;
 
             foreach (var entry in FileAccessToAccessMaskMap)
                 if ((fileAccess & entry.Key) != 0)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -19,6 +19,8 @@ namespace SMBLibrary.Client
             set => throw new NotImplementedException();
         }
 
+        public string Name => GetFileInformation<FileAlternateNameInformation>().FileName;
+
         private readonly object m_handle;
         private readonly ISMBFileStore m_store;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -154,6 +154,8 @@ namespace SMBLibrary.Client
                     throw new ArgumentException($"{fileMode} must be combined with FileAccess.Write.");
             }
 
+            //FILE_APPEND_DATA is not requested even when fileMode == FileMode.Append because
+            //the stream will enforce append constraints by itself.
             var accessMask = (AccessMask)(fileAccess & FileAccess.ReadWrite) | AccessMask.FILE_READ_ATTRIBUTES;
 
             //Possibly replace this with commented code below

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -104,6 +104,9 @@ namespace SMBLibrary.Client
 
             if (fileMode == FileMode.Append)
             {
+                if ((fileAccess & FileAccess.Read) != 0)
+                    throw new ArgumentException("FileMode.Append cannot be combined with FileAccess.Read");
+
                 if ((fileAccess & FileAccess.Write) == 0)
                     throw new ArgumentException("FileMode.Append must be combined with FileAccess.Write");
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -19,6 +19,9 @@ namespace SMBLibrary.Client
             set => throw new NotImplementedException();
         }
 
+        private readonly object m_handle;
+        private readonly ISMBFileStore m_store;
+
         private bool m_disposed;
 
         public override void Flush() => throw new NotImplementedException();

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -209,7 +209,7 @@ namespace SMBLibrary.Client
             if (!CanRead)
                 throw new NotSupportedException();
 
-            var maxBytes = Math.Min(MaxReadSize, destination.Length);
+            var maxBytes = Math.Min(MaxReadSize, count);
             var read = 0;
 
             while (read < maxBytes)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -146,14 +146,14 @@ namespace SMBLibrary.Client
 
             m_handle = handle;
             m_ownsStore = ownsStore;
-            m_earliestSeekablePosition =
-                fileMode == FileMode.Append ? GetFileInformation<FileStandardInformation>().EndOfFile : 0;
             m_store = store;
 
             m_position = m_earliestSeekablePosition;
             m_disposed = false;
 
             Name = GetFileInformation<FileAlternateNameInformation>().FileName;
+            m_earliestSeekablePosition =
+                fileMode == FileMode.Append ? GetFileInformation<FileStandardInformation>().EndOfFile : 0;
             m_accessMask = GetFileInformation<FileAccessInformation>().AccessFlags;
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -90,7 +90,31 @@ namespace SMBLibrary.Client
                 : throw new IOException($"Could not set SMB file position. Error status: {result}");
         }
 
-        public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+        public override int Read(byte[] destination, int offset, int count)
+        {
+            if (m_disposed)
+                throw new ObjectDisposedException(nameof(SMBFileStream));
+
+            if (count == 0)
+                return 0;
+
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (destination.Length - offset < count)
+                throw new ArgumentException("Offset and count exceed destination bounds.");
+
+            if (!CanRead)
+                throw new NotSupportedException();
+
+            throw new NotImplementedException();
+        }
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -11,7 +11,7 @@ namespace SMBLibrary.Client
 
         public override bool CanSeek => throw new NotImplementedException();
 
-        public override long Length => throw new NotImplementedException();
+        public override long Length => GetFileInformation<FileStandardInformation>().EndOfFile;
 
         public override long Position
         {

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -86,7 +86,19 @@ namespace SMBLibrary.Client
                 //TODO: throw FileNotFoundException if file does not exist
             }
 
-            var accessMask = (AccessMask)0; //TODO
+            var accessMask = (AccessMask)0;
+
+            if (fileMode == FileMode.Append)
+            {
+                if ((fileAccess & FileAccess.Write) == 0)
+                    throw new ArgumentException("FileMode.Append must be combined with FileAccess.Write");
+
+                accessMask |= FileAppendData;
+            }
+
+            foreach (var entry in FileAccessToAccessMaskMap)
+                if ((fileAccess & entry.Key) != 0)
+                    accessMask |= entry.Value;
 
             var fileAttributes = (FileAttributes)0; //TODO
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -53,7 +53,7 @@ namespace SMBLibrary.Client
 
         public override long Position
         {
-            get => GetFileInformation<FilePositionInformation>().CurrentByteOffset;
+            get => m_disposed ? throw new ObjectDisposedException(GetType().FullName) : m_position;
             set => Seek(value, SeekOrigin.Begin);
         }
 
@@ -69,6 +69,7 @@ namespace SMBLibrary.Client
         private readonly bool m_ownsStore;
         private readonly ISMBFileStore m_store;
 
+        private long m_position;
         private bool m_disposed;
 
         public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
@@ -143,7 +144,10 @@ namespace SMBLibrary.Client
             if (value < 0)
                 throw new ArgumentOutOfRangeException(nameof(value), "The length of the file must be 0 or greater.");
 
-            m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
+            var status = m_store.SetFileInformation(m_handle, new FileEndOfFileInformation { EndOfFile = value });
+
+            if (status == NTStatus.STATUS_SUCCESS && m_position > value)
+                m_position = value;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -175,11 +179,8 @@ namespace SMBLibrary.Client
             if (target > length)
                 throw new IOException("Cannot seek past end of stream.");
 
-            var result = m_store.SetFileInformation(m_handle, new FilePositionInformation { CurrentByteOffset = target });
-
-            return result == NTStatus.STATUS_SUCCESS
-                ? target
-                : throw new IOException($"Could not set SMB file position. Error status: {result}");
+            m_position = target;
+            return m_position;
         }
 
         public override int Read(byte[] destination, int offset, int count)
@@ -205,14 +206,12 @@ namespace SMBLibrary.Client
             if (!CanRead)
                 throw new NotSupportedException();
 
-            var startingPosition = GetFileInformation<FilePositionInformation>().CurrentByteOffset;
-
             var maxBytes = Math.Min(MaxReadSize, destination.Length);
             var read = 0;
 
             while (read < maxBytes)
             {
-                var status = m_store.ReadFile(out var bytes, m_handle, startingPosition + read, maxBytes - read);
+                var status = m_store.ReadFile(out var bytes, m_handle, m_position + read, maxBytes - read);
 
                 if ((status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE) || bytes.Length == 0)
                     break;
@@ -224,6 +223,7 @@ namespace SMBLibrary.Client
                     break;
             }
 
+            m_position += read;
             return read;
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -36,6 +36,13 @@ namespace SMBLibrary.Client
 
         private bool m_disposed;
 
+        public SMBFileStream(ISMBFileStore store, string path, FileMode fileMode,
+            FileAccess fileAccess = FileAccess.ReadWrite, FileShare fileShare = FileShare.Read,
+            FileOptions fileOptions = FileOptions.None)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void Flush()
         {
             if (m_disposed)

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -143,6 +143,11 @@ namespace SMBLibrary.Client
             if (!CanWrite)
                 throw new NotSupportedException();
 
+            var maxWriteSize = MaxWriteSize;
+
+            if (source.Length > MaxWriteSize)
+                throw new IOException($"Write size exceeds maximum write size of {maxWriteSize} bytes.");
+
             throw new NotImplementedException();
         }
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -156,9 +156,6 @@ namespace SMBLibrary.Client
 
             var accessMask = (AccessMask)(fileAccess & FileAccess.ReadWrite) | AccessMask.FILE_READ_ATTRIBUTES;
 
-            if (append)
-                accessMask |= AccessMask.FILE_APPEND_DATA;
-
             //Possibly replace this with commented code below
             const FileAttributes fileAttributes = FileAttributes.Normal;
 

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -40,7 +40,6 @@ namespace SMBLibrary.Client
                 { FileOptions.DeleteOnClose, CreateOptions.FILE_DELETE_ON_CLOSE },
                 //{ FileOptions.SequentialScan, CreateOptions.FILE_SEQUENTIAL_ONLY },
                 { FileOptions.RandomAccess, CreateOptions.FILE_RANDOM_ACCESS },
-                //{ FileOptions.Asynchronous, CreateOptions. },
             };
 
         public override bool CanRead => !m_disposed && (m_accessMask & FileReadData) != 0;

--- a/SMBLibrary/Client/SMBFileStream.cs
+++ b/SMBLibrary/Client/SMBFileStream.cs
@@ -61,7 +61,7 @@ namespace SMBLibrary.Client
 
         public int MaxWriteSize => (int)Math.Min(int.MaxValue, m_store.MaxWriteSize);
 
-        public string Name => GetFileInformation<FileAlternateNameInformation>().FileName;
+        public string Name { get; }
 
         private AccessMask AccessMask => GetFileInformation<FileAccessInformation>().AccessFlags;
 
@@ -125,6 +125,8 @@ namespace SMBLibrary.Client
             m_ownsStore = ownsStore;
             m_store = store;
             m_disposed = false;
+
+            Name = GetFileInformation<FileAlternateNameInformation>().FileName;
         }
 
         public override void Flush()

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
@@ -10,7 +10,6 @@ namespace SMBLibrary
     {
         FILE_READ_DATA = 0x00000001,
         FILE_WRITE_DATA = 0x00000002,
-        FILE_APPEND_DATA = 0x00000004,
         FILE_READ_ATTRIBUTES = 0x00000080,
 
         // The bits in positions 16 through 31 are object specific.

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
@@ -10,7 +10,6 @@ namespace SMBLibrary
     {
         FILE_READ_DATA = 0x00000001,
         FILE_WRITE_DATA = 0x00000002,
-        FILE_READ_ATTRIBUTES = 0x00000080,
 
         // The bits in positions 16 through 31 are object specific.
         DELETE = 0x00010000,

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
@@ -8,6 +8,10 @@ namespace SMBLibrary
     [Flags]
     public enum AccessMask : uint
     {
+        FILE_READ_DATA = 0x00000001,
+        FILE_WRITE_DATA = 0x00000002,
+        FILE_APPEND_DATA = 0x00000004,
+
         // The bits in positions 16 through 31 are object specific.
         DELETE = 0x00010000,
         READ_CONTROL = 0x00020000,

--- a/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
+++ b/SMBLibrary/NTFileStore/Enums/AccessMask/AccessMask.cs
@@ -11,6 +11,7 @@ namespace SMBLibrary
         FILE_READ_DATA = 0x00000001,
         FILE_WRITE_DATA = 0x00000002,
         FILE_APPEND_DATA = 0x00000004,
+        FILE_READ_ATTRIBUTES = 0x00000080,
 
         // The bits in positions 16 through 31 are object specific.
         DELETE = 0x00010000,

--- a/SMBLibrary/NTFileStore/Enums/FileInformation/FileInformationClass.cs
+++ b/SMBLibrary/NTFileStore/Enums/FileInformation/FileInformationClass.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary
         FileInternalInformation = 0x06,        // Uses: Query
         FileEaInformation = 0x07,              // Uses: Query
         FileAccessInformation = 0x08,          // Uses: Query
-        FileNameInformation = 0x09,            // Uses: LOCAL
+        FileNameInformation = 0x09,            // Uses: Query
         FileRenameInformation = 0x0A,          // Uses: Set
         FileLinkInformation = 0x0B,            // Uses: Set
         FileNamesInformation = 0x0C,           // Uses: Query

--- a/SMBLibrary/NTFileStore/Structures/FileInformation/FileInformation.cs
+++ b/SMBLibrary/NTFileStore/Structures/FileInformation/FileInformation.cs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2021 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+/* Copyright (C) 2017-2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
  * 
  * You can redistribute this program and/or modify it under the terms of
  * the GNU Lesser Public License as published by the Free Software Foundation,
@@ -45,6 +45,8 @@ namespace SMBLibrary
                     return new FileEaInformation(buffer, offset);
                 case FileInformationClass.FileAccessInformation:
                     return new FileAccessInformation(buffer, offset);
+                case FileInformationClass.FileNameInformation:
+                    return new FileNameInformation(buffer, offset);
                 case FileInformationClass.FileRenameInformation:
                     return new FileRenameInformationType2(buffer, offset);
                 case FileInformationClass.FileLinkInformation:


### PR DESCRIPTION
The main contribution in this request is an implementation of System.IO.Stream that allows stream-based I/O with SMB file handles. There are two constructors: one modeled after the main constructor for System.IO.FileStream using a store, relative path string, & BCL enum/flag types; and one that directly takes a store and pre-created file handle.

There are also two minor additions made to the library in support of SMBFileStream:

1. Explicit entries for AccessMask.FILE_READ_DATA & AccessMask.FILE_WRITE_DATA have been added to AccessMask.
2. An entry for querying standalone FileNameInformation has been added to FileInformation.GetFileInformation().