### PR TITLE
SMB2Client: Update the security data during authentication

### DIFF
--- a/SMBLibrary/Client/Authentication/NTLMAuthenticationClient.cs
+++ b/SMBLibrary/Client/Authentication/NTLMAuthenticationClient.cs
@@ -109,6 +109,10 @@ namespace SMBLibrary.Client.Authentication
                 challengeMessageBytes = securityBlob;
             }
 
+            // When NegState is AcceptCompleted or Reject, the SPNEGO token may not contain a Response Token
+            if (challengeMessageBytes == null)
+                return null;
+
             byte[] authenticateMessageBytes = NTLMAuthenticationHelper.GetAuthenticateMessage(m_negotiateMessageBytes, challengeMessageBytes, m_domainName, m_userName, m_password, m_spn, m_authenticationMethod, out m_sessionKey);
             if (useGSSAPI && authenticateMessageBytes != null)
             {

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -299,6 +299,16 @@ namespace SMBLibrary.Client
                 if (m_isLoggedIn)
                 {
                     m_sessionID = response.Header.SessionID;
+                    if (finalSessionSetupResponse.SecurityBuffer != null && finalSessionSetupResponse.SecurityBuffer.Length > 0)
+                    {
+                        // Some authentication mechanisms (e.g. Kerberos) embed acceptor-provider
+                        // context data (such as an AP-REP subkey) in the final, successful
+                        // SESSION_SETUP response. Give the authentication client a chance to
+                        // process it before deriving the session key, since it may override
+                        // the key negotiated so far.
+                        authenticationClient.InitializeSecurityContext(finalSessionSetupResponse.SecurityBuffer);
+                    }
+
                     m_sessionKey = authenticationClient.GetSessionKey();
                     m_authenticationClient = authenticationClient;
                     SessionFlags sessionFlags = finalSessionSetupResponse.SessionFlags;


### PR DESCRIPTION
Hello TalAloni,
Thank you for working on this amazing library!

I found an issue related to implementing Kerberos signing and encryption, and I would like to suggest a small fix for it. I would be glad if I could help improve this library.

According to **RFC 4120** (The Kerberos Network Authentication Service (V5)), **Section 3.2.6** (Using the Encryption Key), page 34:
`One way that an application may choose to negotiate a key to be used for subsequent integrity and privacy protection is for the client to propose a key in the subkey field of the authenticator. The server can then choose a key using the key proposed by the client as input, returning the new subkey in the subkey field of the application reply. This key could then be used for subsequent communication.`

Therefore, the SMB2Client should send the security data back to the authenticator so that it can correctly generate a new session key.