### PR TITLE
Client: DFS: Request the DFS referral before the tree connect

### DIFF
--- a/SMBLibrary.Tests/Client/SMB2DfsFileStoreTests.cs
+++ b/SMBLibrary.Tests/Client/SMB2DfsFileStoreTests.cs
@@ -244,6 +244,60 @@ namespace SMBLibrary.Tests.Client
             Assert.AreEqual("file.txt", targetStore.LastCreateFilePath);
         }
 
+        [TestMethod]
+        public void GetNamespaceTargets_ReturnsTargetsInReferralOrder()
+        {
+            // MS-DFSC 3.1.5.4.3: referral targets are listed in order of preference, so the order
+            // the server gave them in has to be preserved.
+            ResponseGetDfsReferral referral = new ResponseGetDfsReferral();
+            referral.ReferralEntries.Add(new DfsReferralEntryV4() { ServerType = DfsServerType.Root, DfsPath = @"\lab.local\Namespace", NetworkAddress = @"\NS1.lab.local\Namespace" });
+            referral.ReferralEntries.Add(new DfsReferralEntryV4() { ServerType = DfsServerType.Root, DfsPath = @"\lab.local\Namespace", NetworkAddress = @"\NS2.lab.local\Namespace" });
+
+            List<DfsPath> targets = DfsNamespaceResolver.GetNamespaceTargets(referral);
+
+            Assert.AreEqual(2, targets.Count);
+            // A root referral names the namespace server by FQDN, not by short name.
+            Assert.AreEqual("NS1.lab.local", targets[0].ServerName);
+            Assert.AreEqual("Namespace", targets[0].ShareName);
+            Assert.AreEqual("NS2.lab.local", targets[1].ServerName);
+        }
+
+        [TestMethod]
+        public void GetNamespaceTargets_SkipsEntriesThatAreNotRootTargets()
+        {
+            // MS-DFSC 2.2.4.3: only a root target names a namespace server. Resolution runs ahead
+            // of every tree connect, so treating a link target as a namespace server would divert
+            // an ordinary tree connect to a server it was never asked to reach.
+            ResponseGetDfsReferral referral = new ResponseGetDfsReferral();
+            referral.ReferralEntries.Add(new DfsReferralEntryV4() { ServerType = DfsServerType.NonRoot, NetworkAddress = @"\LINK-TARGET\Share" });
+            referral.ReferralEntries.Add(new DfsReferralEntryV4() { ServerType = DfsServerType.Root, NetworkAddress = @"\NS1\Namespace" });
+
+            List<DfsPath> targets = DfsNamespaceResolver.GetNamespaceTargets(referral);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual("NS1", targets[0].ServerName);
+        }
+
+        [TestMethod]
+        public void IsSameServer_MatchesOnlyTheSameHost()
+        {
+            // A root referral names its target by FQDN while the caller will often have connected
+            // by short name, so both spellings have to name one host. Treating distinct hosts as
+            // one would skip a target the referral named, which is how a namespace becomes
+            // unreachable, so anything less certain than that has to be treated as a second host.
+            Assert.IsTrue(DfsNamespaceResolver.IsSameServer("NS1", "NS1.lab.local"));
+            Assert.IsTrue(DfsNamespaceResolver.IsSameServer("NS1.lab.local", "NS1"));
+            Assert.IsTrue(DfsNamespaceResolver.IsSameServer("ns1", "NS1"));
+            Assert.IsTrue(DfsNamespaceResolver.IsSameServer("10.0.0.5", "10.0.0.5"));
+
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("10.0.0.5", "10.0.0.9"));
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("192.168.1.10", "192.168.1.20"));
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("NS1.a.local", "NS1.b.local"));
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("NS1", "NS2.lab.local"));
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("NS1", "NS10.lab.local"));
+            Assert.IsFalse(DfsNamespaceResolver.IsSameServer("NS1", null));
+        }
+
         private static byte[] BuildReferral(string dfsPath, params string[] networkAddresses)
         {
             ResponseGetDfsReferral referral = new ResponseGetDfsReferral();

--- a/SMBLibrary/Client/DFS/DfsNamespaceResolver.cs
+++ b/SMBLibrary/Client/DFS/DfsNamespaceResolver.cs
@@ -1,0 +1,216 @@
+﻿/* Copyright (C) 2026 Tal Aloni <tal.aloni.il@gmail.com>. All rights reserved.
+ * 
+ * You can redistribute this program and/or modify it under the terms of
+ * the GNU Lesser Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ */
+using System;
+using System.Collections.Generic;
+using SMBLibrary.DFS;
+
+namespace SMBLibrary.Client.DFS
+{
+    /// <summary>
+    /// [MS-DFSC] Resolves a share to the namespace server that hosts it, before a tree connect is
+    /// attempted. A domain-based namespace is addressed as 'domain\namespace', where the first
+    /// component names the domain rather than a server, so no host serves a share by that name and
+    /// only a root referral can name one that does.
+    /// </summary>
+    internal class DfsNamespaceResolver
+    {
+        /// <summary>
+        /// Requests a DFS referral for the share and tree connects to the namespace server it
+        /// names, connecting to that server first when it is not the one already connected to.
+        /// Returns null when the path is not a DFS namespace, or when no target could be reached,
+        /// leaving the caller to tree connect to the current server exactly as it would have done
+        /// had this never been attempted.
+        /// </summary>
+        internal static ISMBFileStore TryResolveNamespace(SMB2Client client, string serverName, string shareName, out NTStatus status)
+        {
+            status = NTStatus.STATUS_BAD_NETWORK_NAME;
+
+            // Resolving IPC$ would mean requesting a referral over a tree connect to the very
+            // share being resolved. Windows does not request a referral for it either.
+            if (String.Equals(shareName, "IPC$", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            List<DfsPath> targets = GetNamespaceServers(client, serverName, shareName);
+            foreach (DfsPath target in targets)
+            {
+                NTStatus targetStatus;
+                if (IsSameServer(serverName, target.ServerName))
+                {
+                    // A namespace root hosted by the server already connected to - a standalone
+                    // namespace, or a domain-based one this server happens to host. Reuse the
+                    // connection rather than open a second one to the same host. The root referral
+                    // identifies the namespace even if TREE_CONNECT omits the optional DFS_ROOT flag.
+                    ISMBFileStore localStore = client.TreeConnect(target.ShareName, false, out targetStatus);
+                    if (targetStatus == NTStatus.STATUS_SUCCESS && localStore != null)
+                    {
+                        status = targetStatus;
+                        return localStore as SMB2DfsFileStore ?? new SMB2DfsFileStore(client, serverName, target.ShareName, localStore);
+                    }
+
+                    // MS-DFSC 3.1.5.4.3: targets are listed in order of preference, so a target
+                    // that cannot be reached just means trying the next one.
+                    continue;
+                }
+
+                SMB2Client namespaceClient = client.ConnectAndLoginToDfsTarget(target.ServerName);
+                if (namespaceClient == null)
+                {
+                    continue;
+                }
+
+                // Do not resolve again from here: a namespace server answering
+                // STATUS_BAD_NETWORK_NAME is a dead end, not another referral to follow.
+                ISMBFileStore fileStore = namespaceClient.TreeConnect(target.ShareName, false, out targetStatus);
+                if (targetStatus == NTStatus.STATUS_SUCCESS && fileStore != null)
+                {
+                    // [MS-SMB2] 3.3.5.7: DFS_ROOT is optional. A successful connection to a target
+                    // from a root referral is sufficient to wrap the store as a namespace root.
+                    SMB2DfsFileStore dfsFileStore = fileStore as SMB2DfsFileStore ??
+                        new SMB2DfsFileStore(namespaceClient, target.ServerName, target.ShareName, fileStore);
+                    // The caller never created this connection, so the store it is handed owns it
+                    // and releases it on Disconnect - the same rule that already applies to the
+                    // connections opened when following a link referral.
+                    dfsFileStore.TakeOwnershipOf(namespaceClient);
+                    status = targetStatus;
+                    return dfsFileStore;
+                }
+
+                namespaceClient.LogoffAndDisconnect();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Selects the namespace servers named by a root referral, in the order the server listed
+        /// them - MS-DFSC 3.1.5.4.3 states they are ordered by preference.
+        /// Only V3 and V4 entries carry NetworkAddress, so V1 and V2 entries cannot name a target.
+        /// </summary>
+        internal static List<DfsPath> GetNamespaceTargets(ResponseGetDfsReferral referralResponse)
+        {
+            List<DfsPath> targets = new List<DfsPath>();
+            if (referralResponse == null)
+            {
+                return targets;
+            }
+
+            foreach (DfsReferralEntry referralEntry in referralResponse.ReferralEntries)
+            {
+                DfsReferralEntryV3 entry = referralEntry as DfsReferralEntryV3;
+                if (entry == null || String.IsNullOrEmpty(entry.NetworkAddress))
+                {
+                    continue;
+                }
+
+                // MS-DFSC 2.2.4.3: a root referral names root targets. An entry reporting anything
+                // else is a link or storage target, not a namespace server, and following it would
+                // send the tree connect to a server it was never asked to reach.
+                if (entry.ServerType != DfsServerType.Root)
+                {
+                    continue;
+                }
+
+                DfsPath target;
+                try
+                {
+                    target = new DfsPath(entry.NetworkAddress);
+                }
+                catch (ArgumentException)
+                {
+                    // A network address that contains no path components. Skip the entry rather
+                    // than discard the targets named by the entries around it.
+                    continue;
+                }
+
+                if (!String.IsNullOrEmpty(target.ShareName))
+                {
+                    targets.Add(target);
+                }
+            }
+
+            return targets;
+        }
+
+        private static List<DfsPath> GetNamespaceServers(SMB2Client client, string serverName, string shareName)
+        {
+            NTStatus ipcStatus;
+            ISMBFileStore ipcStore = client.TreeConnect("IPC$", false, out ipcStatus);
+            if (ipcStatus != NTStatus.STATUS_SUCCESS || ipcStore == null)
+            {
+                return new List<DfsPath>();
+            }
+
+            try
+            {
+                ResponseGetDfsReferral referralResponse;
+                string namespacePath = @"\\" + serverName + @"\" + shareName;
+                NTStatus status = DfsReferralHelper.GetDfsReferral(ipcStore, namespacePath, out referralResponse);
+                if (status != NTStatus.STATUS_SUCCESS)
+                {
+                    return new List<DfsPath>();
+                }
+
+                return GetNamespaceTargets(referralResponse);
+            }
+            catch
+            {
+                // e.g. a malformed referral response buffer
+                return new List<DfsPath>();
+            }
+            finally
+            {
+                try
+                {
+                    ipcStore.Disconnect();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+        }
+
+        /// <summary>
+        /// A referral names its target by fully qualified name, while the caller may have connected
+        /// by short name, or the other way round.
+        /// Deliberately conservative: reporting two distinct hosts as one would skip a target the
+        /// referral named, while failing to recognise the same host only costs a second connection
+        /// to it.
+        /// </summary>
+        internal static bool IsSameServer(string serverName, string targetServerName)
+        {
+            if (String.IsNullOrEmpty(serverName) || String.IsNullOrEmpty(targetServerName))
+            {
+                return false;
+            }
+
+            if (String.Equals(serverName, targetServerName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return IsShortNameOf(serverName, targetServerName) || IsShortNameOf(targetServerName, serverName);
+        }
+
+        /// <summary>
+        /// True when shortName is a single label and fullName is that same label with a DNS suffix.
+        /// A dotted quad is never a single label, so two addresses on one network - 10.0.0.5 and
+        /// 10.0.0.9 - are not taken for the same host.
+        /// </summary>
+        private static bool IsShortNameOf(string shortName, string fullName)
+        {
+            if (shortName.IndexOf('.') >= 0 || fullName.Length <= shortName.Length)
+            {
+                return false;
+            }
+
+            return fullName[shortName.Length] == '.' &&
+                   String.Compare(fullName, 0, shortName, 0, shortName.Length, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+    }
+}

--- a/SMBLibrary/Client/DFS/SMB2DfsFileStore.cs
+++ b/SMBLibrary/Client/DFS/SMB2DfsFileStore.cs
@@ -27,6 +27,10 @@ namespace SMBLibrary.Client.DFS
         private string m_shareName;
         private ISMBFileStore m_dfsFileStore;
         private bool m_useDfsPaths;
+        // The connection to a namespace server, opened on the caller's behalf while resolving a
+        // root referral. The caller holds no reference to it, so this store releases it on
+        // Disconnect, exactly as it does for the connections opened to follow a link referral.
+        private SMB2Client m_ownedClient;
 
         // Connections and tree connections established while following referrals to other targets.
         private Dictionary<string, SMB2Client> m_targetClients;
@@ -49,6 +53,11 @@ namespace SMBLibrary.Client.DFS
             // to a share that happens to carry SMB2_SHAREFLAG_DFS_ROOT keeps working exactly as it did before.
             m_useDfsPaths = !IsIPAddress(serverName);
             SetDfsOperations(m_dfsFileStore, m_useDfsPaths);
+        }
+
+        internal void TakeOwnershipOf(SMB2Client client)
+        {
+            m_ownedClient = client;
         }
 
         private static bool IsIPAddress(string serverName)
@@ -246,7 +255,9 @@ namespace SMBLibrary.Client.DFS
             }
 
             NTStatus status;
-            ISMBFileStore fileStore = client.TreeConnect(shareName, out status);
+            // A referral is already being followed here, so a target share that is not found is a
+            // dead end to move past rather than the start of another referral chain.
+            ISMBFileStore fileStore = client.TreeConnect(shareName, false, out status);
             if (status != NTStatus.STATUS_SUCCESS)
             {
                 return null;
@@ -401,18 +412,24 @@ namespace SMBLibrary.Client.DFS
 
             foreach (SMB2Client client in m_targetClients.Values)
             {
-                try
-                {
-                    client.Logoff();
-                }
-                catch (InvalidOperationException)
-                {
-                }
-                client.Disconnect();
+                client.LogoffAndDisconnect();
             }
             m_targetClients.Clear();
 
-            return m_dfsFileStore.Disconnect();
+            try
+            {
+                return m_dfsFileStore.Disconnect();
+            }
+            finally
+            {
+                // In a finally because the disconnect above throws when the connection is already
+                // gone, which is exactly when the client still needs closing.
+                if (m_ownedClient != null)
+                {
+                    m_ownedClient.LogoffAndDisconnect();
+                    m_ownedClient = null;
+                }
+            }
         }
 
         private DfsHandle GetDfsHandle(object handle)

--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -37,6 +37,7 @@ namespace SMBLibrary.Client
         private ConnectionState m_connectionState;
         private int m_responseTimeoutInMilliseconds;
         private bool m_enableSMB311Support = false;
+        private bool m_resolveDfsNamespace = true;
 
         private object m_incomingQueueLock = new object();
         private List<SMB2Command> m_incomingQueue = new List<SMB2Command>();
@@ -75,10 +76,20 @@ namespace SMBLibrary.Client
         {
         }
 
-        public SMB2Client(int responseTimeoutInMilliseconds, bool enableSMB311Support)
+        public SMB2Client(int responseTimeoutInMilliseconds, bool enableSMB311Support) : this(responseTimeoutInMilliseconds, enableSMB311Support, true)
+        {
+        }
+
+        /// <param name="resolveDfsNamespace">
+        /// Request a DFS referral for a share before connecting to it, and tree connect to the
+        /// namespace server the referral names. When false, every tree connect goes to the server
+        /// this client is connected to. Referrals below a namespace root are followed either way.
+        /// </param>
+        public SMB2Client(int responseTimeoutInMilliseconds, bool enableSMB311Support, bool resolveDfsNamespace)
         {
             m_responseTimeoutInMilliseconds = responseTimeoutInMilliseconds;
             m_enableSMB311Support = enableSMB311Support;
+            m_resolveDfsNamespace = resolveDfsNamespace;
         }
 
         /// <param name="serverName">
@@ -347,6 +358,34 @@ namespace SMBLibrary.Client
             return NTStatus.STATUS_INVALID_SMB;
         }
 
+        /// <summary>
+        /// Releases a connection that is being abandoned, without reporting how it went. Neither
+        /// call may throw: connections opened while following DFS referrals are released during a
+        /// tree connect, where an exception would surface on a path that has never thrown.
+        /// </summary>
+        internal void LogoffAndDisconnect()
+        {
+            try
+            {
+                Logoff();
+            }
+            catch
+            {
+                // Logoff can also fail when a timed-out request consumed the last SMB credit.
+            }
+            finally
+            {
+                try
+                {
+                    Disconnect();
+                }
+                catch
+                {
+                    // Socket.Disconnect throws once the socket is gone
+                }
+            }
+        }
+
         public List<string> ListShares(out NTStatus status)
         {
             if (!m_isConnected || !m_isLoggedIn)
@@ -354,7 +393,8 @@ namespace SMBLibrary.Client
                 throw new InvalidOperationException("A login session must be successfully established before retrieving share list");
             }
 
-            ISMBFileStore namedPipeShare = TreeConnect("IPC$", out status);
+            // IPC$ is never a DFS namespace, so there is nothing to resolve.
+            ISMBFileStore namedPipeShare = TreeConnect("IPC$", false, out status);
             if (namedPipeShare == null)
             {
                 return null;
@@ -367,9 +407,31 @@ namespace SMBLibrary.Client
 
         public ISMBFileStore TreeConnect(string shareName, out NTStatus status)
         {
+            return TreeConnect(shareName, m_resolveDfsNamespace, out status);
+        }
+
+        /// <param name="resolveDfsNamespace">
+        /// Request a DFS referral for the share before connecting, and connect to the namespace
+        /// server it names. Suppressed while already resolving one, so a referral cannot chain
+        /// indefinitely.
+        /// </param>
+        internal ISMBFileStore TreeConnect(string shareName, bool resolveDfsNamespace, out NTStatus status)
+        {
             if (!m_isConnected || !m_isLoggedIn)
             {
                 throw new InvalidOperationException("A login session must be successfully established before connecting to a share");
+            }
+
+            if (resolveDfsNamespace)
+            {
+                // [MS-DFSC] The share may name a DFS namespace rather than a share on this host.
+                // Anything short of a referral naming another server returns null and leaves the
+                // direct tree connect below to answer, as it did before any of this was attempted.
+                ISMBFileStore namespaceStore = DfsNamespaceResolver.TryResolveNamespace(this, m_serverName, shareName, out status);
+                if (namespaceStore != null)
+                {
+                    return namespaceStore;
+                }
             }
 
             string sharePath = String.Format(@"\\{0}\{1}", m_serverName, shareName);
@@ -840,7 +902,7 @@ namespace SMBLibrary.Client
                 return null;
             }
 
-            SMB2Client targetClient = new SMB2Client(m_responseTimeoutInMilliseconds, m_enableSMB311Support);
+            SMB2Client targetClient = new SMB2Client(m_responseTimeoutInMilliseconds, m_enableSMB311Support, m_resolveDfsNamespace);
             try
             {
                 if (!targetClient.Connect(serverName, m_transport))


### PR DESCRIPTION
Step 2 from #358, reordered to query first per your comment.

## Problem

`\\domain\namespace` names the AD domain, not a server, so `TreeConnect` returns
`STATUS_BAD_NETWORK_NAME`. A DFS root referral names the servers that host the
namespace.

## Change

Request a DFS referral for the share before the tree connect, and tree connect to the
server the referral names. A referral answered with `STATUS_NOT_FOUND` identifies an
ordinary share, which is then tree connected directly. Nothing is sent that is expected
to fail.

This is the order Windows uses, confirmed against a capture: it requests a referral over
IPC$ for every path, including paths that turn out not to be DFS.

Targets are restricted to root targets (MS-DFSC 2.2.4.3), and a referral naming the
server already connected to reuses that connection rather than opening a second one. Any
failure — IPC$ unreachable, referral refused, no usable target — falls through to the
direct tree connect, so a server that works today is unaffected.

All of it is in `SMBLibrary.Client.DFS`. `SMB2Client` gets an internal overload and one
call that delegates. No public API change.

## Cost

Three extra requests per `TreeConnect` against a non-DFS server: IPC$ tree connect, the
referral, IPC$ tree disconnect. On the lab an ordinary share went from 12 to 18 SMB2
messages, and a domain namespace from 16 to 14.

Holding the IPC$ tree open and reusing it, as Windows does, would take that to one after
the first tree connect on a connection. Not in this PR.

## Testing

Windows Server 2022, domain-based namespace hosted on a member server, with a link to a
share on a second server. The namespace resolves and the link traverses. An ordinary
share on an ordinary server still connects and is not wrapped as a DFS root. The
returned store owns the namespace connection and releases it on `Disconnect`; note
`client.Logoff()` won't release it.

```
dotnet test SMBLibrary.Tests -f net6.0    77 passed, 0 failed
dotnet test SMBLibrary.Tests -f net472    77 passed, 0 failed
```

Builds clean on net20, net40 and netstandard2.0.
